### PR TITLE
 dependency version for junit is missing in alfresco-sdk-parent 1.2.0-SNAPSHOT

### DIFF
--- a/poms/alfresco-sdk-parent/pom.xml
+++ b/poms/alfresco-sdk-parent/pom.xml
@@ -526,6 +526,7 @@
         	<dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
                 <scope>test</scope>
               </dependency>
               <!-- Add RAD capabilities for remote JUnit test running. Scope=test so the custom JUnit remote runner is found in the Maven test classpath -->


### PR DESCRIPTION
The version number  for junit dependency should be explicity declared in cases of multi-module projects inheritnig from the alfresco-sdk-parent archetype (1.2.0-SNAPSHOT and 2.0.0-SNAPSHOT). 
See my raised issue
https://github.com/Alfresco/alfresco-sdk/issues/240
