### PR TITLE
Alfresco 5.0.1 supports Java 8, but Maven Compiler settings are hardcode...

### DIFF
--- a/poms/alfresco-sdk-parent/pom.xml
+++ b/poms/alfresco-sdk-parent/pom.xml
@@ -128,6 +128,8 @@
 
         <!-- Maven Plugins Versions used by the SDK -->
         <maven.compiler.version>3.2</maven.compiler.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <maven.clean.version>2.6.1</maven.clean.version>
         <maven.dependency.version>2.9</maven.dependency.version>
         <maven.enforcer.plugin>1.3.1</maven.enforcer.plugin>
@@ -231,8 +233,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.version}</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/poms/alfresco-sdk-parent/pom.xml
+++ b/poms/alfresco-sdk-parent/pom.xml
@@ -232,10 +232,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.version}</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Alfresco 5.0.1 supports Java 8, but Maven Compiler settings are hardcoded to 1.7.

With this change, compiling Java 8 code for 5.0.1 is possible by overwriting the properties:

maven.compiler.target : 1.8
maven.compiler.source: 1.8
