### PR TITLE
change activation of enforce-sdk-rules so it's *really* on by default, as intended

### DIFF
--- a/poms/alfresco-sdk-parent/pom.xml
+++ b/poms/alfresco-sdk-parent/pom.xml
@@ -866,7 +866,7 @@
         <profile>
             <id>enforce-sdk-rules</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activation><file><missing>does-not-exist.tmp</missing></file></activation><!-- turn on this profile (by triggering on a file that is not expected to exist) -->
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
Maven's "active by default" does behave intuitively.  If you turn on any other profiles, then the "active by default" ones are turned off.  

As a result, using the "enterprise" profile turns off "enforce-sdk-rules", which I believe was unintended.

I use a bit of a hack to fix this (looking for a non-existent file).  

From the maven docs:  "All profiles that are active by default are automatically deactivated when a profile in the POM is activated on the command line or through its activation config."

http://maven.apache.org/guides/introduction/introduction-to-profiles.html