### PR TITLE
make run.sh executable during the "validation" phase of the build

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -104,5 +104,35 @@
                 <maven.alfresco.includeWebResources>false</maven.alfresco.includeWebResources>
             </properties>
         </profile>
+
+	<!-- if we're on a unix machine, chmod run.sh to be executable -->        
+        <profile>
+        	<id>chmod</id>
+        	<activation><os><family>unix</family></os></activation>
+        	<build>
+        		<plugins>
+		            <plugin>
+		              <groupId>org.codehaus.mojo</groupId>
+		              <artifactId>exec-maven-plugin</artifactId>
+		              <version>1.2.1</version>
+		              <inherited>false</inherited>
+		              <executions>
+		              	<execution>
+		              		<id>chmod</id>
+		              		<phase>validate</phase>
+		              		<goals><goal>exec</goal></goals>
+		              	</execution>
+		              </executions>
+		              <configuration>
+		              	<executable>chmod</executable>
+		              	<arguments>
+		              		<argument>+x</argument>
+		              		<argument>${basedir}/run.sh</argument>
+		              	</arguments>
+		              </configuration>
+		            </plugin>
+        		</plugins>
+        	</build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
If you run archetype:generate with `-Dgoals=validate` (and this patch), then your generated project has an executable run.sh.

Best solution I could come up with.