### PR TITLE
The current configuration doesn't encode url:s tomcat7-maven-plugin.

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/runner/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/runner/pom.xml
@@ -110,6 +110,8 @@
                                  This also fixes issues with the Google Guava Library, which this tomcat plugin uses
                                  version 10.0.1 of but Solr uses 14.0.1 -->
                             <delegate>false</delegate>
+                            <!-- Encode url in UTF-8 for proper character handling -->
+                            <uriEncoding>UTF-8</uriEncoding>
                             <webapps>
                                 <webapp>
                                     <groupId>${project.groupId}</groupId>

--- a/poms/alfresco-sdk-parent/pom.xml
+++ b/poms/alfresco-sdk-parent/pom.xml
@@ -634,6 +634,8 @@
                                     </systemProperties>
                                     <delegate>true</delegate>
                                     <contextFile>${project.basedir}/tomcat/context.xml</contextFile>
+                                    <!-- Encode url in UTF-8 for proper character handling -->
+                                    <uriEncoding>UTF-8</uriEncoding>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
The current configuration doesn't encode url:s properly and this breaks any pages/webscripts that uses parameters that contains non us-ascii characters. Adding the uriEncoding solves this.