### PR TITLE
Logo image source link was dead. Fixed that to use the logo published…

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -9,7 +9,7 @@
           <topBarIcon>
             <name>Alfresco Software</name>
             <alt>Alfresco Software</alt>
-            <src>http://people.apache.org/~gabriele/Alfresco-logo-transparent-thin.png</src>
+            <src>https://wiki.alfresco.com/skins/alfresco/community_theme/alfresco-org-logo.png</src>
             <href>http://www.alfresco.com</href>
           </topBarIcon>
           <topBarEnabled>true</topBarEnabled>


### PR DESCRIPTION
… on wiki.alfresco.com.