### PR TITLE
Unset failOnMissingWebXml flag

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/repo/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/repo/pom.xml
@@ -77,6 +77,7 @@
                         | explicitly mention it in the overlay section.
                         | NOTE: First-win resource strategy is used by the WAR plugin
                          -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
                     <overlays>
                         <!-- Current project customizations. This is normally empty, since customizations come from the AMPs -->
                         <overlay/>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/share/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/share/pom.xml
@@ -72,6 +72,7 @@
                 <configuration>
                     <!-- Bring in the MANIFEST.MF file from the original share.war, it contains version information
                          that is needed for it to operate properly -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
                     <archive>
                         <addMavenDescriptor>false</addMavenDescriptor>
                         <manifestFile>${project.build.directory}/dependency/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
The default value for the `failOnMissingWebXml` flag is causing eclipse IDE to complain about a missing web.xml file, note that the file is already packaged within the base war (to be fetched from alfresco's artifacts repository) itself, and thereby is not mandatory on the project skeleton.
