### PR TITLE
Added support for native Windows HTTP authentication (Kerberos).

### DIFF
--- a/plugins/alfresco-maven-plugin/pom.xml
+++ b/plugins/alfresco-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.alfresco.maven.plugin</groupId>
   <artifactId>alfresco-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Maven Alfresco Plugin</name>
+  <name>Maven Alfresco Plugin with support for native Windows HTTP authentication.</name>
 
   <parent>
       <groupId>org.alfresco.maven</groupId>
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <artifactId>httpclient-win</artifactId>
       <version>4.5.1</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Minor SDK plugin change that adds support for native Windows HTTP authentication that can be enabled through an additional configurable Maven plugin parameter:

`<configuration><useWinAuth>true</useWinAuth></configuration>`

This functionality is particularly useful if you're using the Alfresco SDK with Rapid Application Deployment (RAD) in a Windows environment with Kerberos tokens (or similar). Please remember that the user running the plugin has to have administrator privileges within the Alfresco/Share installation in order to flush caches etc.

If the plugin cannot find the native Windows HTTP client library (e.g. if the plugin is running on a different OS), it will echo a warning message and fall back on the default behavior.
