### PR TITLE
chore(github) : new github issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,67 @@
+<!--
+
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information within 7 days, we cannot debug your issue and will close it. We
+will, however, reopen it if you later provide the information.
+
+---------------------------------------------------
+GENERAL SUPPORT INFORMATION
+---------------------------------------------------
+
+The GitHub issue tracker is for bug reports and feature requests.
+General support can be found at the following locations:
+
+- Alfresco Community - https://community.alfresco.com/community/ecm
+- Post a question on StackOverflow, using the Alfresco tag
+
+-->
+
+
+## I'm submitting a ...   (check one with "x")
+```
+[ ] bug report => search github for a similar issue or PR before submitting
+[ ] feature request
+```
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+5.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Alfresco SDK version used: <!-- 2.1 / 2.2 / 3.0betaX-->
+* Alfresco version used: <!-- Enterprise 5.1, Community 5.0.f or ...-->
+* Output of command 'mvn -version': <!-- Maven/JDK version--> 
+* Link to your project: <!-- optional for having a minimal example-->
+
+## Additional information
+<!-- include screenshots or any other hint you mave have for us -->


### PR DESCRIPTION
This commit provides an issue template which will be used when users will report a bug or suggest a new feature.
This should help to provide better and quicker support for the reported issues of alfresco SDK.