### PR TITLE
Artifact ID fix for platform WAR

### DIFF
--- a/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
+++ b/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
@@ -299,7 +299,7 @@ public abstract class AbstractRunMojo extends AbstractMojo {
     @Parameter(property = "activiti.groupId", defaultValue = "com.activiti")
     protected String activitiGroupId;
 
-    @Parameter(property = "alfresco.platform.war.artifactId", defaultValue = "alfresco")
+    @Parameter(property = "alfresco.platform.war.artifactId", defaultValue = "alfresco-platform")
     protected String alfrescoPlatformWarArtifactId;
 
     @Parameter(property = "alfresco.share.war.artifactId", defaultValue = "share")


### PR DESCRIPTION
Default platform artifact ID seems to have changed in 93dde46 commit from "alfresco-platform" to "alfresco". Works until latest 201701 release of community as WARs are still available under "alfresco" artifactId. From 201702 community release there does not seem to be an alfresco.war artifact with artifactId "alfresco" and version 5.2.f, only available with artifactId "alfresco-platform". 