### PR TITLE
Made the runtest ftl-files null-safe

### DIFF
--- a/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.html.ftl
+++ b/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.html.ftl
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>${test?html}</title>
+    <title>${test!?html}</title>
     <script language="JavaScript">
         function showdiv(id) {
             //safe function to show an element with a specified id
@@ -20,13 +20,13 @@
     </script>
 </head>
 <body>
-<h1>Integration Test: ${test?html}</h1>
-<div><b>Result:</b> ${result}</div>
+<h1>Integration Test: ${test!?html}</h1>
+<div><b>Result:</b> ${result!}</div>
 <#if failures??>
     <#list failures as failure>
-    <div id="testHeader"><b>${failure.getTestHeader()?html}</b></div>
-    <div id="message"><a href="#" onclick="showdiv('trace');return false;">${failure.getMessage()?html}</a></div>
-    <div id="trace" style="display:none;"><pre>${failure.getTrace()?html}</pre></div>
+    <div id="testHeader"><b>${failure.getTestHeader()!?html}</b></div>
+    <div id="message"><a href="#" onclick="showdiv('trace');return false;">${failure.getMessage()!?html}</a></div>
+    <div id="trace" style="display:none;"><pre>${failure.getTrace()!?html}</pre></div>
     <br/>
     </#list>
 </#if>

--- a/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.xml.ftl
+++ b/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.xml.ftl
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
-    <test>${test?html}</test>
-    <result>${result?html}</result>
+    <test>${test!?html}</test>
+    <result>${result!?html}</result>
 <#if failures??>
     <failures>
         <#list failures as failure>
-            <trace>${failure.getTrace()?html}</trace>
-            <exception>${failure.getException()?html}</exception>
-            <message>${failure.getMessage()?html}</message>
-            <testHeader>${failure.getTestHeader()?html}</testHeader>
+            <trace>${failure.getTrace()!?html}</trace>
+            <exception>${failure.getException()!?html}</exception>
+            <message>${failure.getMessage()!?html}</message>
+            <testHeader>${failure.getTestHeader()!?html}</testHeader>
         </#list>
     </failures>
 </#if>
-    <failureCount>${failureCount?html}</failureCount>
-    <ignoreCount>${ignoreCount?html}</ignoreCount>
-    <runCount>${runCount?html}</runCount>
-    <runTime>${runTime?html}</runTime>
+    <failureCount>${failureCount!?html}</failureCount>
+    <ignoreCount>${ignoreCount!?html}</ignoreCount>
+    <runCount>${runCount!?html}</runCount>
+    <runTime>${runTime!?html}</runTime>
 <#if throwables??>
     <throwables>
         <#list throwables as throwable>
-            <throwable>${throwable?html}</throwable>
+            <throwable>${throwable!?html}</throwable>
         </#list>
     </throwables>
 </#if>


### PR DESCRIPTION
When some tests did fail for various reasons in our SDK-3 based project, we got ftl errors in the surefire output and no meaningful test results other than information on that the test failed.

It was tracked down to empty exception messages or traces being output by the Alfresco code which the runtest ftl files did not handle well.

**Example before fix:**

```
2017-06-07 09:00:50,615  DEBUG [alfresco.it.SitePolicyIT] [http-bio-8765-exec-10] Searching for folder_3_0
 RunTestWebScript: model = {result=FAILURE, throwables=[xxx], failures=[testSiteFolderStructureTemplateCopyIntegrity(xxx.SitePolicyIT): null], test=xxx.SitePolicyIT#testSiteFolderStructureTemplateCopyIntegrity#testSiteFolderStructureTemplateCopyIntegrity, ignoreCount=0, wasSuccessful=false, runTime=1556, runCount=1, resultObject=org.junit.runner.Result@606d9d5c, failureCount=1}
RunTestWebScript: Stopped executing
2017-06-07 09:00:50,923  ERROR [freemarker.runtime] [http-bio-8765-exec-10] Error executing FreeMarker template
 FreeMarker template error:
The following has evaluated to null or missing:
==> failure.getMessage()  [in template "org/alfresco/rad/test/runtest.get.xml.ftl" at line 10, column 24]

Tip: If the failing expression is known to be legally null/missing, either specify a default value with myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthessis: (myOptionVar.foo)!myDefault, (myOptionVar.foo)??

The failing instruction (FTL stack trace):
----------
==> ${failure.getMessage()?html}  [in template "org/alfresco/rad/test/runtest.get.xml.ftl" at line 10, column 22]
----------

Java stack trace (for programmers):
----------
freemarker.core.InvalidReferenceException: [... Exception message was already printed; see it above ...]
	at freemarker.core.InvalidReferenceException.getInstance(InvalidReferenceException.java:98)
	at freemarker.core.EvalUtil.coerceModelToString(EvalUtil.java:382)
	at freemarker.core.Expression.evalAndCoerceToString(Expression.java:115)
	at freemarker.core.StringBuiltins$StringBuiltIn._eval(StringBuiltins.java:87)
	at freemarker.core.Expression.eval(Expression.java:111)
	at freemarker.core.Expression.evalAndCoerceToString(Expression.java:115)
	at freemarker.core.DollarVariable.accept(DollarVariable.java:76)
	at freemarker.core.Environment.visit(Environment.java:265)
	at freemarker.core.MixedContent.accept(MixedContent.java:93)
	at freemarker.core.Environment.visitByHiddingParent(Environment.java:286)
	at freemarker.core.IteratorBlock$Context.runLoop(IteratorBlock.java:193)
	at freemarker.core.Environment.visitIteratorBlock(Environment.java:509)
	at freemarker.core.IteratorBlock.accept(IteratorBlock.java:103)
	at freemarker.core.Environment.visit(Environment.java:265)
	at freemarker.core.MixedContent.accept(MixedContent.java:93)
	at freemarker.core.Environment.visitByHiddingParent(Environment.java:286)
	at freemarker.core.ConditionalBlock.accept(ConditionalBlock.java:86)
	at freemarker.core.Environment.visit(Environment.java:265)
	at freemarker.core.MixedContent.accept(MixedContent.java:93)
	at freemarker.core.Environment.visit(Environment.java:265)
	at freemarker.core.Environment.process(Environment.java:243)
	at org.alfresco.repo.template.FreeMarkerProcessor.process(FreeMarkerProcessor.java:230)
	at org.springframework.extensions.webscripts.AbstractWebScript.renderTemplate(AbstractWebScript.java:967)
	at org.springframework.extensions.webscripts.DeclarativeWebScript.renderFormatTemplate(DeclarativeWebScript.java:267)
	at org.springframework.extensions.webscripts.DeclarativeWebScript.execute(DeclarativeWebScript.java:147)
	at org.alfresco.repo.web.scripts.RepositoryContainer$3.execute(RepositoryContainer.java:519)
	at org.alfresco.repo.transaction.RetryingTransactionHelper.doInTransaction(RetryingTransactionHelper.java:464)
	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecute(RepositoryContainer.java:587)
	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecuteAs(RepositoryContainer.java:656)
	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScriptInternal(RepositoryContainer.java:428)
	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScript(RepositoryContainer.java:308)
	at org.springframework.extensions.webscripts.AbstractRuntime.executeScript(AbstractRuntime.java:399)
	at org.springframework.extensions.webscripts.AbstractRuntime.executeScript(AbstractRuntime.java:210)
	at org.springframework.extensions.webscripts.servlet.WebScriptServlet.service(WebScriptServlet.java:132)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:770)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:305)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at org.alfresco.web.app.servlet.GlobalLocalizationFilter.doFilter(GlobalLocalizationFilter.java:68)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:222)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:123)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:502)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:171)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:100)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:953)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:118)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:408)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1041)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:603)
	at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:312)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```


**Example after fix:**
```

 2017-06-07 08:02:09,351  DEBUG [alfresco.it.SitePolicyIT] [http-bio-8765-exec-3] Searching for folder_3_0
 RunTestWebScript: model = {result=FAILURE, throwables=[...], failures=[testSiteFolderStructureTemplateCopyIntegrity(xxx.SitePolicyIT): null], test=xxx.SitePolicyIT#testSiteFolderStructureTemplateCopyIntegrity#testSiteFolderStructureTemplateCopyIntegrity, ignoreCount=0, wasSuccessful=false, runTime=1515, runCount=1, resultObject=org.junit.runner.Result@c8e6eb9, failureCount=1}
RunTestWebScript: Stopped executing
2017-06-07 08:02:10,241  ERROR [extensions.webscripts.AbstractRuntime] [http-bio-8765-exec-3] Exception from executeScript: 05070043 Failed to execute transaction-level behaviour public abstract void org.alfresco.repo.node.NodeServicePolicies$OnAddAspectPolicy.onAddAspect(org.alfresco.service.cmr.repository.NodeRef,org.alfresco.service.namespace.QName) in transaction f0ecda51-40f5-4fe4-99e0-42a3465ffcf5
 org.alfresco.error.AlfrescoRuntimeException: 05070043 Failed to execute transaction-level behaviour public abstract void org.alfresco.repo.node.NodeServicePolicies$OnAddAspectPolicy.onAddAspect(org.alfresco.service.cmr.repository.NodeRef,org.alfresco.service.namespace.QName) in transaction f0ecda51-40f5-4fe4-99e0-42a3465ffcf5
```