### PR TITLE
Feature request: adding support for custom solr config #474

### DIFF
--- a/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
+++ b/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
@@ -450,6 +450,35 @@ public abstract class AbstractRunMojo extends AbstractMojo {
     }
 
     /**
+     * Copy custom solr configuration files over, so a 
+     * developer can overwrite any files needed
+     * 
+     * @throws MojoExecutionException
+     */
+    protected void copySolrCustomConfig() throws MojoExecutionException {
+    	getLog().info("Copying custom Solr config");
+        executeMojo(
+                plugin(
+                        groupId("org.apache.maven.plugins"),
+                        artifactId("maven-resources-plugin"),
+                        version(MAVEN_RESOURCE_PLUGIN_VERSION)
+                ),
+                goal("copy-resources"),
+                configuration(
+                        element(name("outputDirectory"), solrHome),
+                        element(name("overwrite"), "true"),
+                        element(name("resources"),
+                                element(name("resource"),
+                                        element(name("directory"), "src/test/resources/solr"),
+                                        element(name("filtering"), "true")
+                                )
+                        )
+                ),
+                execEnv
+        );
+    }
+    
+    /**
      * Replace property placeholders in configuration files for the cores, so the
      * index files can be found for each core when Solr starts up.
      *

--- a/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/RunMojo.java
+++ b/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/RunMojo.java
@@ -49,6 +49,7 @@ public class RunMojo extends AbstractRunMojo {
         if (enableSolr) {
             unpackSolrConfig();
             fixSolrHomePath();
+            copySolrCustomConfig();
             replaceSolrConfigProperties();
             installSolr10InLocalRepo();
         }


### PR DESCRIPTION
Have a folder "src/test/resources/solr" in which you can put in custom solr configuration files, which will be automatically injected into "alf_data_dev/solr", so a developer can overwrite any files needed. If a developer doesn't need this feature he/she can simply leave that folder empty.