### PR TITLE
Nullpointer in code crashes Freemarker evaluation within Integration Testing

### DIFF
--- a/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.html.ftl
+++ b/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.html.ftl
@@ -25,7 +25,7 @@
 <#if failures??>
     <#list failures as failure>
     <div id="testHeader"><b>${failure.getTestHeader()?html}</b></div>
-    <div id="message"><a href="#" onclick="showdiv('trace');return false;">${failure.getMessage()?html}</a></div>
+    <div id="message"><a href="#" onclick="showdiv('trace');return false;">${failure.getMessage()!""?html}</a></div>
     <div id="trace" style="display:none;"><pre>${failure.getTrace()?html}</pre></div>
     <br/>
     </#list>

--- a/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.xml.ftl
+++ b/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.xml.ftl
@@ -7,7 +7,7 @@
         <#list failures as failure>
             <trace>${failure.getTrace()?html}</trace>
             <exception>${failure.getException()?html}</exception>
-            <message>${failure.getMessage()?html}</message>
+            <message>${failure.getMessage()!""?html}</message>
             <testHeader>${failure.getTestHeader()?html}</testHeader>
         </#list>
     </failures>


### PR DESCRIPTION
See Issue https://github.com/Alfresco/alfresco-sdk/issues/478

A nullpointer in an Integration tests causes an error in Freemarker evaluation because the error message will be null and the template is not designed to handle this case. This could confuse the developer, because the integration test ends with an error like below, instead of a message about the nullpointer.

This is caused by the fact that message of JUnit's Failure class delegates to getMessage() of the throwable which can be null in some cases (Nullpointer for instance) causing the Freemarker template evaluation to fail which in turn hides the real problem in the integration test.
```

Caused by: freemarker.core.InvalidReferenceException: The following has evaluated to null or missing:
==> failure.getMessage()  [in template "org/alfresco/rad/test/runtest.get.xml.ftl" at line 10, column 24]

Tip: If the failing expression is known to be legally null/missing, either specify a default value with myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthessis: (myOptionVar.foo)!myDefault, (myOptionVar.foo)??

The failing instruction:
==> ${failure.getMessage()?html}  [in template "org/alfresco/rad/test/runtest.get.xml.ftl" at line 10, column 22]
        at freemarker.core.InvalidReferenceException.getInstance(InvalidReferenceException.java:98)
        at freemarker.core.EvalUtil.coerceModelToString(EvalUtil.java:382)
        at freemarker.core.Expression.evalAndCoerceToString(Expression.java:115)
        at freemarker.core.StringBuiltins$StringBuiltIn._eval(StringBuiltins.java:87)
        at freemarker.core.Expression.eval(Expression.java:111)
        at freemarker.core.Expression.evalAndCoerceToString(Expression.java:115)
        at freemarker.core.DollarVariable.accept(DollarVariable.java:76)
        at freemarker.core.Environment.visit(Environment.java:265)
        at freemarker.core.MixedContent.accept(MixedContent.java:93)
        at freemarker.core.Environment.visitByHiddingParent(Environment.java:286)
        at freemarker.core.IteratorBlock$Context.runLoop(IteratorBlock.java:193)
        at freemarker.core.Environment.visitIteratorBlock(Environment.java:509)
        at freemarker.core.IteratorBlock.accept(IteratorBlock.java:103)
        at freemarker.core.Environment.visit(Environment.java:265)
        at freemarker.core.MixedContent.accept(MixedContent.java:93)
        at freemarker.core.Environment.visitByHiddingParent(Environment.java:286)
        at freemarker.core.ConditionalBlock.accept(ConditionalBlock.java:86)
        at freemarker.core.Environment.visit(Environment.java:265)
        at freemarker.core.MixedContent.accept(MixedContent.java:93)
        at freemarker.core.Environment.visit(Environment.java:265)
        at freemarker.core.Environment.process(Environment.java:243)
        at org.alfresco.repo.template.FreeMarkerProcessor.process(FreeMarkerProcessor.java:230)
        ... 35 more
```