### PR TITLE
Fix null check to work with assertEqual-failures and exception messages containing reserved xml characters

### DIFF
--- a/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.xml.ftl
+++ b/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.xml.ftl
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
-    <test>${test?html}</test>
-    <result>${result?html}</result>
+    <test>${test?xml}</test>
+    <result>${result?xml}</result>
 <#if failures??>
     <failures>
         <#list failures as failure>
-            <trace>${failure.getTrace()?html}</trace>
-            <exception>${failure.getException()?html}</exception>
-            <message>${failure.getMessage()!""?html}</message>
-            <testHeader>${failure.getTestHeader()?html}</testHeader>
+            <trace>${failure.getTrace()?xml}</trace>
+            <exception>${failure.getException()?xml}</exception>
+            <message>${failure.getMessage()!?xml}</message>
+            <testHeader>${failure.getTestHeader()?xml}</testHeader>
         </#list>
     </failures>
 </#if>
-    <failureCount>${failureCount?html}</failureCount>
-    <ignoreCount>${ignoreCount?html}</ignoreCount>
-    <runCount>${runCount?html}</runCount>
-    <runTime>${runTime?html}</runTime>
+    <failureCount>${failureCount?xml}</failureCount>
+    <ignoreCount>${ignoreCount?xml}</ignoreCount>
+    <runCount>${runCount?xml}</runCount>
+    <runTime>${runTime?xml}</runTime>
 <#if throwables??>
     <throwables>
         <#list throwables as throwable>
-            <throwable>${throwable?html}</throwable>
+            <throwable>${throwable?xml}</throwable>
         </#list>
     </throwables>
 </#if>


### PR DESCRIPTION
<!--

If you are reporting a new issue, make sure that we do not have any duplicates
already open. You can ensure this by searching the issue list for this
repository. If there is a duplicate, please close your issue and add a comment
to the existing issue instead.

If you suspect your issue is a bug, please edit your issue description to
include the BUG REPORT INFORMATION shown below. If you fail to provide this
information within 7 days, we cannot debug your issue and will close it. We
will, however, reopen it if you later provide the information.

---------------------------------------------------
GENERAL SUPPORT INFORMATION
---------------------------------------------------

The GitHub issue tracker is for bug reports and feature requests.
General support can be found at the following locations:

- Alfresco Community - https://community.alfresco.com/community/ecm
- Post a question on StackOverflow, using the Alfresco tag

-->


## I'm submitting a ...   (check one with "x")
```
[x] bug report => search github for a similar issue or PR before submitting
[ ] feature request
```

<!--- Provide a general summary of the issue in the Title above -->

## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
We are having issues with assertEquals comparisons in integration tests. With the latest 3.0.2-SNAPSHOT the PR #477 was included to fix null pointer exceptions in the runtest.get.xml.ftl file. The PR fixed the null pointer errors but introduced new errors which come from the usage of using freemarker expressions ${test!""?html} where we would expect that the contents of the ftl variable test would first have a null check and then be html escaped. The observed behaviour however is that a null check is made but no html escape is made.

The correct freemarker expresson to use would be ${test!?html} or ${test!?xml} depending on the ftl type.

## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
<!--- or ideas how to implement the addition or change -->

This PR fixes runtest.get.xml.ftl and should be merged asap to master.

## Steps to Reproduce (for bugs)
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. create a new integration test
2. create a junit assertEquals("example failing assertEquals", 601, 613)
3. run the test and notice the saxparseexception  which is due to the junit message which contain < and > which are not escaped correctly
4.
5.

## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Alfresco SDK version used: 3.0.2-SNAPSHOT
* Alfresco version used: 5.2
* Output of command 'mvn -version': <!-- Maven/JDK version--> 
$ mvn -version
Apache Maven 3.5.0 (ff8f5e7444045639af65f6095c62210b5713f426; 2017-04-03T21:39:06+02:00)
Maven home: /usr/local/Cellar/maven/3.5.0/libexec
Java version: 1.8.0_112, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13", arch: "x86_64", family: "mac"
* Link to your project: <!-- optional for having a minimal example-->

## Additional information
<!-- include screenshots or any other hint you mave have for us -->