### PR TITLE
BUGFIX - Allow to write test methods in abstract classes

### DIFF
--- a/modules/alfresco-rad/src/main/java/org/alfresco/rad/test/AlfrescoTestRunner.java
+++ b/modules/alfresco-rad/src/main/java/org/alfresco/rad/test/AlfrescoTestRunner.java
@@ -110,7 +110,7 @@ public class AlfrescoTestRunner extends BlockJUnit4ClassRunner {
     protected void callProxiedChild(FrameworkMethod method, RunNotifier notifier, Description desc) {
         notifier.fireTestStarted(desc);
 
-        String className = method.getMethod().getDeclaringClass().getCanonicalName();
+        String className = this.getTestClass().getJavaClass().getCanonicalName();
         String methodName = method.getName();
         if (null != methodName) {
             className += "#" + methodName;


### PR DESCRIPTION
We asume we are in the following case where we have an abstract class which declares some test methods :

```
@RunWith(AlfrescoTestRunner.class)
public abstract class AbstractIT {

    @Test    
    public void test() {
        doSomeThing(abstractMethod());
    }

    abstract protected Object abstractMethod();
    ...
}
```

And several test classes extending the abstract class above, and which are run during integration-test phase :

```
public class ChildIT extends AbstractIT {
    @Override
    protected Object abstractMethod() {
        ...
    }
}
```
Currently, when the AlfrescoTestRunner builds the name of the test methods to be run before sending it to the RunTestWebscript, it resolves the class name by getting the declaringClass of the test method, which is "AbstractIT" in our case.

So in our case, the RunTestWebscript will receive the instruction to run the method **AbstractIT#test** and it will result with an InstantiationException thrown when JUnit will try to instantiate AbstractIT (since it is an abstract class).

With this little modification, the AlfrescoTestRunner will send to RunTestWebscript the name of the class which is actually beeing tested, i.e **ChildIT#test** .
