### PR TITLE
Do not run test methods in a transaction by default

### DIFF
--- a/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.desc.xml
+++ b/modules/alfresco-rad/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/rad/test/runtest.get.desc.xml
@@ -26,6 +26,7 @@
     <format default="html">any</format>
     <lifecycle>internal</lifecycle>
     <authentication>user</authentication>
+    <transaction>none</transaction>
     <family>Alfresco SDK</family>
     <cache>
         <never>false</never>


### PR DESCRIPTION
Tests might throw ConcurrencyFailureException or CannotAcquireLockException when performing two operations on a node.

This is because a transaction is initiated by default when calling the RunTestWebscript since this webscript requires authentication.

A solution is to force the WS not to initiate a transaction and leave this option to the developpers. 