### PR TITLE
Make the Solr indexation frequency customizable

### DIFF
--- a/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
+++ b/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
@@ -352,6 +352,12 @@ public abstract class AbstractRunMojo extends AbstractMojo {
     protected String solrHome;
 
     /**
+     * Solr indexation frequency. It is customizable to speed up integration tests execution.
+     */
+    @Parameter(property = "solr.alfresco.cron", defaultValue = "0/15 * * * * ? *")
+    protected String solrCron;
+
+    /**
      * Maven GAV properties for customized alfresco.war, share.war, activiti-app.war
      * Used by the Maven Tomcat 7 Plugin
      */
@@ -531,8 +537,11 @@ public abstract class AbstractRunMojo extends AbstractMojo {
                                 element(name("replacement"),
                                         element(name("token"), "alfresco.secureComms=https"),
                                         element(name("value"), "alfresco.secureComms=none")
+                                ),
+                                element(name("replacement"),
+                                        element(name("token"), "alfresco.cron=0/15 * * * * ? *"),
+                                        element(name("value"), "alfresco.cron=" + solrCron)
                                 )
-
                         )
                 ),
                 execEnv


### PR DESCRIPTION
Solr4 indexes transactions every 15 seconds by default and it is currently not customizable in the SDK.
In SDK 2 it was possible to use lucene as a search system during integration tests, and indexing was then almost imediate. 

While migrating some projects to the SDK 3, we had to modify many tests to wait 16 seconds before executing methods which perform a search.
It makes the execution of all tests very long. For this reason we'd like the indexation frequency (property **alfresco.cron** in solrcore.properties) to be customizable so that we can set it to 5 seconds for example.

