### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/archetypes/alfresco-allinone-archetype/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/pom.xml
@@ -7,14 +7,14 @@
   <packaging>maven-archetype</packaging>
   <name>Alfresco SDK - All-in-One Archetype</name>
   <description>Sample multi-module project for All-in-One development on the Alfresco platform. Includes modules for Platform/Repository JAR and Share JAR</description>
-  
+
   <parent>
     <groupId>org.alfresco.maven</groupId>
     <artifactId>alfresco-sdk-aggregator</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-  
+
   <build>
     <resources>
         <resource>

--- a/archetypes/alfresco-platform-jar-archetype/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.alfresco.maven</groupId>
     <artifactId>alfresco-sdk-aggregator</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/archetypes/alfresco-share-jar-archetype/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/alfresco-rad/pom.xml
+++ b/modules/alfresco-rad/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugins/alfresco-maven-plugin/pom.xml
+++ b/plugins/alfresco-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco.maven</groupId>
     <artifactId>alfresco-sdk-aggregator</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>Alfresco SDK</name>
     <description>This aggregator Project builds all modules required for the Alfresco SDK</description>
     <packaging>pom</packaging>
@@ -30,7 +30,7 @@
         <connection>scm:git:${scm.url.base}.git</connection>
         <developerConnection>scm:git:${scm.url.base}</developerConnection>
         <url>${scm.url.base}</url>
-      <tag>alfresco-sdk-aggregator-3.0.0-SNAPSHOT</tag>
+      <tag>alfresco-sdk-aggregator-4.0.0-SNAPSHOT</tag>
   </scm>
 
     <developers>
@@ -337,7 +337,7 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>                
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Bumping up the version number entries to 4.0.0 in all pom files.

Tests aren't running successfully afterwards, but they weren't on the SDK-4.0 branch neither. I assume more fixing is needed here.