### PR TITLE
Bumping version number to 4.0 for documentation + descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the home of the Alfresco SDK. The Alfresco SDK is used by developers to build extensions for the Alfresco Digital Business Platform. It is based on [Apache Maven](http://maven.apache.org/), compatible with major IDEs and enables Rapid Application Development (RAD) and Test Driven Development (TDD).
 
 ## License
-This project is released under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) license. 
+This project is released under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) license.
 If you are an Enterprise customer check the [Support](#alfresco-enterprise-customers-and-partners-support) section.
 
 ## News
@@ -21,11 +21,12 @@ If you are an Enterprise customer check the [Support](#alfresco-enterprise-custo
 ## User Getting Started
 
 ### Latest Documentation
-To get started with **Alfresco SDK 3.0.x** (latest) visit the [Alfresco Documentation](https://docs.alfresco.com/5.2/concepts/sdk-intro.html) 
+To get started with **Alfresco SDK 4.0.x** (latest) visit the [Alfresco Documentation](https://docs.alfresco.com/6.0/concepts/dev-for-developers.html) (documentation pending).
 
 #### Documentation about Previous Versions
-| SDK Version  | Alfresco Enterprise Version       |  Alfresco Community Version       | Documentation  | 
+| SDK Version  | Alfresco Enterprise Version       |  Alfresco Community Version       | Documentation  |
 | ------------- |:-------------:| :-----:|:-----|
+| SDK 3.0   | Alfresco 5.2.x | Alfresco 5.2.x | http://docs.alfresco.com/5.2/concepts/sdk-intro.html |
 | SDK 2.2   | Alfresco 5.1.x | Alfresco 5.1.x | https://docs.alfresco.com/5.1/concepts/alfresco-sdk-intro.html |
 | SDK 2.1   | Alfresco 5.0.1 | Alfresco 5.0.d | https://docs.alfresco.com/sdk2.1/concepts/alfresco-sdk-intro.html |
 | SDK 2.0   | Alfresco 5.0.0 | Alfresco 5.0.c | https://docs.alfresco.com/sdk2.0/concepts/alfresco-sdk-intro.html |
@@ -37,8 +38,8 @@ To get started with **Alfresco SDK 3.0.x** (latest) visit the [Alfresco Document
 Report issues (and contribute!) [here](https://github.com/Alfresco/alfresco-sdk/issues?milestone=1&state=open) or join us on the [IRC Channel](http://chat.alfresco.com/).
 
 ## Alfresco Enterprise Customers and Partners Support
-If you are an Alfresco Customer 
-please check the [SDK Support status](http://www.alfresco.com/services/subscription/technical-support/product-support-status) 
+If you are an Alfresco Customer
+please check the [SDK Support status](http://www.alfresco.com/services/subscription/technical-support/product-support-status)
 for the version you are using.  If your version is in Limited or Full Support and you need help, visit the [Support Portal](http://support.alfresco.com).
 
 ## Maven repositories
@@ -46,7 +47,7 @@ for the version you are using.  If your version is in Limited or Full Support an
 - Alfresco (Community and Enterprise) artifacts are  hosted in the [Alfresco Artifacts Repository](https://artifacts.alfresco.com/).
 - Alfresco Community artifacts (JARs, WARs, AMPs, poms) and SDK artifacts are publicly available.
 
-*NOTE:* By default the Alfresco SDK will use Community Edition releases but it can be configured to use Enterprise Edition releases.  Enterprise and Premier customers can use the SDK with 
+*NOTE:* By default the Alfresco SDK will use Community Edition releases but it can be configured to use Enterprise Edition releases.  Enterprise and Premier customers can use the SDK with
 Enterprise Edition releases by following the process described in [Working with Enterprise](https://docs.alfresco.com/5.2/concepts/sdk-using-enterprise.html)
 
 ### Alfresco Artifacts Repository
@@ -73,4 +74,3 @@ To test new unreleased (unsupported) features, you can use the following snippet
 
 ## For Developers that want to contribute to the SDK
 See the [Developers Wiki page](https://github.com/Alfresco/alfresco-sdk/wiki/Developer-Wiki).
-

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/README.md
@@ -1,19 +1,19 @@
-# Alfresco AIO Project - SDK 3
+# Alfresco AIO Project - SDK 4.0
 
-This is an All-In-One (AIO) project for Alfresco SDK 3.0. 
+This is an All-In-One (AIO) project for Alfresco SDK 4.0.
 
-Run with `mvn clean install -DskipTests=true alfresco:run` or `./run.sh` and verify that it 
+Run with `mvn clean install -DskipTests=true alfresco:run` or `./run.sh` and verify that it
 
- * Runs the embedded Tomcat + H2 DB 
+ * Runs the embedded Tomcat + H2 DB
  * Runs Alfresco Platform (Repository)
  * Runs Alfresco Solr4
  * Runs Alfresco Share
  * Packages both as JAR and AMP assembly for modules
- 
+
 # Few things to notice
 
  * No parent pom
- * No WAR projects, all handled by the Alfresco Maven Plugin 
+ * No WAR projects, all handled by the Alfresco Maven Plugin
  * No runner project - it's all in the Alfresco Maven Plugin
  * Standard JAR packaging and layout
  * Works seamlessly with Eclipse and IntelliJ IDEA
@@ -23,12 +23,9 @@ Run with `mvn clean install -DskipTests=true alfresco:run` or `./run.sh` and ver
  * No unit testing/functional tests just yet
  * Resources loaded from META-INF
  * Web Fragment (this includes a sample servlet configured via web fragment)
- 
+
 # TODO
- 
+
   * Abstract assembly into a dependency so we don't have to ship the assembly in the archetype
   * Purge
   * Functional/remote unit tests
-   
-  
- 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-jar/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-jar/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>${artifactId}</artifactId>
     <name>Alfresco Platform/Repository JAR Module</name>
-    <description>Platform/Repo JAR Module (to be included in the alfresco.war) - part of AIO - SDK 3
+    <description>Platform/Repo JAR Module (to be included in the alfresco.war) - part of AIO - SDK 4.0
     </description>
     <packaging>jar</packaging>
 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share-jar/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share-jar/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>${artifactId}</artifactId>
     <name>Alfresco Share JAR Module</name>
     <packaging>jar</packaging>
-    <description>Sample Share JAR Module (to be included in the share.war) - part of AIO - SDK 3</description>
+    <description>Sample Share JAR Module (to be included in the share.war) - part of AIO - SDK 4.0</description>
 
     <parent>
         <groupId>${groupId}</groupId>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/integration-tests/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>${artifactId}</artifactId>
     <name>Integration Tests Module</name>
-    <description>Integration Tests module for in-container integration testing - part of AIO - SDK 3</description>
+    <description>Integration Tests module for in-container integration testing - part of AIO - SDK 4.0</description>
     <packaging>jar</packaging> <!-- Note. this just runs Integration Tests, but it needs to be a JAR otherwise
                                             nothing is compiled (i.e. you cannot set it to pom) -->
 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,8 +5,8 @@
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
-    <name>AIO - SDK 3.0</name>
-    <description>All-In-One (AIO) project for SDK 3.0</description>
+    <name>AIO - SDK 4.0</name>
+    <description>All-In-One (AIO) project for SDK 4.0</description>
     <packaging>pom</packaging>
 
     <properties>

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,8 +5,8 @@
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
-    <name>${artifactId} Platform Jar Module - SDK 3</name>
-    <description>Platform JAR Module (to be included in the alfresco.war) - SDK 3</description>
+    <name>${artifactId} Platform Jar Module - SDK 4.0</name>
+    <description>Platform JAR Module (to be included in the alfresco.war) - SDK 4.0</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/README.md
@@ -1,16 +1,16 @@
-# Alfresco Share JAR Module - SDK 3
+# Alfresco Share JAR Module - SDK 4.0
 
-To run this module use `mvn clean install -DskipTests=true alfresco:run` or `./run.sh` and verify that it 
+To run this module use `mvn clean install -DskipTests=true alfresco:run` or `./run.sh` and verify that it
 
- * Runs the embedded Tomcat + H2 DB 
+ * Runs the embedded Tomcat + H2 DB
  * Runs Alfresco Share
  * Packages both as JAR and AMP assembly
 
 Note. You access Share as follows: http://localhost:8081/share
- 
+
 Note. You need an Alfresco Platform instance running at http://localhost:8080/alfresco that Share can talk to.
       Typically you will just kick off a platform-jar module for that.
- 
+
 # Few things to notice
 
  * No parent pom
@@ -23,11 +23,7 @@ Note. You need an Alfresco Platform instance running at http://localhost:8080/al
  * No unit testing/functional tests just yet
  * Resources loaded from META-INF
  * Web Fragment (this includes a sample servlet configured via web fragment)
- 
+
 # TODO
- 
+
   * Abstract assembly into a dependency so we don't have to ship the assembly in the archetype
- 
-   
-  
- 

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,8 +5,8 @@
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
-    <name>${artifactId} Share Jar Module - SDK 3</name>
-    <description>Share JAR Module (to be included in the share.war) - SDK 3</description>
+    <name>${artifactId} Share Jar Module - SDK 4.0</name>
+    <description>Share JAR Module (to be included in the share.war) - SDK 4.0</description>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
The version number bump to 4.0 was still missing in some documentation files and some description elements.