### PR TITLE
Archetypes - Add IT logs

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
@@ -3,6 +3,14 @@
 
 SET COMPOSE_FILE_PATH=%CD%\target\classes\docker\docker-compose.yml
 
+IF [%M2_HOME%]==[] (
+    SET MVN_EXEC=mvn
+)
+
+IF NOT [%M2_HOME%]==[] (
+    SET MVN_EXEC=%M2_HOME%\bin\mvn
+)
+
 IF [%1]==[] (
     echo "Usage: %0 {build_start|start|stop|purge|tail|reload_share|reload_acs|build_test|test}"
     GOTO END
@@ -80,19 +88,19 @@ EXIT /B 0
 :build
     docker rmi alfresco-content-services-${rootArtifactId}:development
     docker rmi alfresco-share-${rootArtifactId}:development
-	call mvn clean install -DskipTests
+	call "%MVN_EXEC%" clean install -DskipTests
 EXIT /B 0
 :build_share
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-share
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-	call mvn clean install -DskipTests -pl ${rootArtifactId}-share-jar
+	call "%MVN_EXEC%" clean install -DskipTests -pl ${rootArtifactId}-share-jar
 EXIT /B 0
 :build_acs
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-acs
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-acs
     docker rmi alfresco-content-services-${rootArtifactId}:development
-	call mvn clean install -DskipTests -pl ${rootArtifactId}-platform-jar
+	call "%MVN_EXEC%" clean install -DskipTests -pl ${rootArtifactId}-platform-jar
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
@@ -101,7 +109,7 @@ EXIT /B 0
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
-    call mvn verify -pl integration-tests
+    call "%MVN_EXEC%" verify -pl integration-tests
 EXIT /B 0
 :purge
     docker volume rm ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
@@ -50,6 +50,7 @@ IF %1==build_test (
     CALL :build
     CALL :start
     CALL :test
+    CALL :tail_all
     CALL :down
     GOTO END
 )
@@ -95,6 +96,9 @@ EXIT /B 0
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
+EXIT /B 0
+:tail_all
+    docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
     call mvn verify -pl integration-tests

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
@@ -88,19 +88,19 @@ EXIT /B 0
 :build
     docker rmi alfresco-content-services-${rootArtifactId}:development
     docker rmi alfresco-share-${rootArtifactId}:development
-	call "%MVN_EXEC%" clean install -DskipTests
+	call %MVN_EXEC% clean install -DskipTests
 EXIT /B 0
 :build_share
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-share
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-	call "%MVN_EXEC%" clean install -DskipTests -pl ${rootArtifactId}-share-jar
+	call %MVN_EXEC% clean install -DskipTests -pl ${rootArtifactId}-share-jar
 EXIT /B 0
 :build_acs
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-acs
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-acs
     docker rmi alfresco-content-services-${rootArtifactId}:development
-	call "%MVN_EXEC%" clean install -DskipTests -pl ${rootArtifactId}-platform-jar
+	call %MVN_EXEC% clean install -DskipTests -pl ${rootArtifactId}-platform-jar
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
@@ -109,7 +109,7 @@ EXIT /B 0
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
-    call "%MVN_EXEC%" verify -pl integration-tests
+    call %MVN_EXEC% verify -pl integration-tests
 EXIT /B 0
 :purge
     docker volume rm ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -3,11 +3,11 @@
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
 
-
-
-${symbol_dollar}M2_HOME/bin/mvn -v 2>&1
-
-env
+if [[ -z "${symbol_dollar}{M2_HOME}" ]]; then
+  export MVN_EXEC="mvn"
+else
+  export MVN_EXEC="${symbol_dollar}{M2_HOME}/bin/mvn"
+fi
 
 start() {
     docker volume create ${rootArtifactId}-acs-volume
@@ -37,21 +37,21 @@ purge() {
 build() {
     docker rmi alfresco-content-services-${rootArtifactId}:development
     docker rmi alfresco-share-${rootArtifactId}:development
-    ${symbol_dollar}M2_HOME/bin/mvn clean install -DskipTests=true
+    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true
 }
 
 build_share() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH kill ${rootArtifactId}-share
     yes | docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-    ${symbol_dollar}M2_HOME/bin/mvn clean install -DskipTests=true -pl ${rootArtifactId}-share-jar
+    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true -pl ${rootArtifactId}-share-jar
 }
 
 build_acs() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH kill ${rootArtifactId}-acs
     yes | docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH rm -f ${rootArtifactId}-acs
     docker rmi alfresco-content-services-${rootArtifactId}:development
-    ${symbol_dollar}M2_HOME/bin/mvn clean install -DskipTests=true -pl ${rootArtifactId}-platform-jar
+    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true -pl ${rootArtifactId}-platform-jar
 }
 
 tail() {
@@ -63,7 +63,7 @@ tail_all() {
 }
 
 test() {
-    ${symbol_dollar}M2_HOME/bin/mvn verify -pl integration-tests
+    ${symbol_dollar}MVN_EXEC verify -pl integration-tests
 }
 
 case "${symbol_dollar}1" in

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -52,6 +52,10 @@ tail() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs -f
 }
 
+tail_all() {
+    docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs --tail="all"
+}
+
 test() {
     mvn verify -pl integration-tests
 }
@@ -92,6 +96,7 @@ case "${symbol_dollar}1" in
     build
     start
     test
+    tail_all
     down
     ;;
   test)

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -3,7 +3,7 @@
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
 
-if [[ -z "${symbol_dollar}{M2_HOME}" ]]; then
+if [ -z "${symbol_dollar}{M2_HOME}" ]; then
   export MVN_EXEC="mvn"
 else
   export MVN_EXEC="${symbol_dollar}{M2_HOME}/bin/mvn"

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -2,6 +2,8 @@
 #!/bin/sh
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
+mvn -v
+env
 
 start() {
     docker volume create ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -2,7 +2,11 @@
 #!/bin/sh
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
-mvn -v
+
+
+
+${symbol_dollar}M2_HOME/bin/mvn -v 2>&1
+
 env
 
 start() {
@@ -33,21 +37,21 @@ purge() {
 build() {
     docker rmi alfresco-content-services-${rootArtifactId}:development
     docker rmi alfresco-share-${rootArtifactId}:development
-    mvn clean install -DskipTests=true
+    ${symbol_dollar}M2_HOME/bin/mvn clean install -DskipTests=true
 }
 
 build_share() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH kill ${rootArtifactId}-share
     yes | docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-    mvn clean install -DskipTests=true -pl ${rootArtifactId}-share-jar
+    ${symbol_dollar}M2_HOME/bin/mvn clean install -DskipTests=true -pl ${rootArtifactId}-share-jar
 }
 
 build_acs() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH kill ${rootArtifactId}-acs
     yes | docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH rm -f ${rootArtifactId}-acs
     docker rmi alfresco-content-services-${rootArtifactId}:development
-    mvn clean install -DskipTests=true -pl ${rootArtifactId}-platform-jar
+    ${symbol_dollar}M2_HOME/bin/mvn clean install -DskipTests=true -pl ${rootArtifactId}-platform-jar
 }
 
 tail() {
@@ -59,7 +63,7 @@ tail_all() {
 }
 
 test() {
-    mvn verify -pl integration-tests
+    ${symbol_dollar}M2_HOME/bin/mvn verify -pl integration-tests
 }
 
 case "${symbol_dollar}1" in

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -69,7 +69,7 @@ EXIT /B 0
 EXIT /B 0
 :build
     docker rmi alfresco-content-services-${rootArtifactId}:development
-	call "%MVN_EXEC%" clean install -DskipTests
+	call %MVN_EXEC% clean install -DskipTests
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
@@ -78,7 +78,7 @@ EXIT /B 0
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
-    call "%MVN_EXEC%" verify
+    call %MVN_EXEC% verify
 EXIT /B 0
 :purge
     docker volume rm ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -38,6 +38,7 @@ IF %1==build_test (
     CALL :build
     CALL :start
     CALL :test
+    CALL :tail_all
     CALL :down
     GOTO END
 )
@@ -64,6 +65,9 @@ EXIT /B 0
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
+EXIT /B 0
+:tail_all
+    docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
     call mvn verify

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -3,6 +3,14 @@
 
 SET COMPOSE_FILE_PATH=%CD%\target\classes\docker\docker-compose.yml
 
+IF [%M2_HOME%]==[] (
+    SET MVN_EXEC=mvn
+)
+
+IF NOT [%M2_HOME%]==[] (
+    SET MVN_EXEC=%M2_HOME%\bin\mvn
+)
+
 IF [%1]==[] (
     echo "Usage: %0 {build_start|start|stop|purge|tail|build_test|test}"
     GOTO END
@@ -61,7 +69,7 @@ EXIT /B 0
 EXIT /B 0
 :build
     docker rmi alfresco-content-services-${rootArtifactId}:development
-	call mvn clean install -DskipTests
+	call "%MVN_EXEC%" clean install -DskipTests
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
@@ -70,7 +78,7 @@ EXIT /B 0
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
-    call mvn verify
+    call "%MVN_EXEC%" verify
 EXIT /B 0
 :purge
     docker volume rm ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -3,6 +3,12 @@
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
 
+if [[ -z "${symbol_dollar}{M2_HOME}" ]]; then
+  export MVN_EXEC="mvn"
+else
+  export MVN_EXEC="${symbol_dollar}{M2_HOME}/bin/mvn"
+fi
+
 start() {
     docker volume create ${rootArtifactId}-acs-volume
     docker volume create ${rootArtifactId}-db-volume
@@ -22,7 +28,7 @@ purge() {
 
 build() {
     docker rmi alfresco-content-services-${rootArtifactId}:development
-    mvn clean install -DskipTests=true
+    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true
 }
 
 tail() {
@@ -34,7 +40,7 @@ tail_all() {
 }
 
 test() {
-    mvn verify
+    ${symbol_dollar}MVN_EXEC verify
 }
 
 case "${symbol_dollar}1" in

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -29,6 +29,10 @@ tail() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs -f
 }
 
+tail_all() {
+    docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs --tail="all"
+}
+
 test() {
     mvn verify
 }
@@ -59,6 +63,7 @@ case "${symbol_dollar}1" in
     build
     start
     test
+    tail_all
     down
     ;;
   test)

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -3,7 +3,7 @@
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
 
-if [[ -z "${symbol_dollar}{M2_HOME}" ]]; then
+if [ -z "${symbol_dollar}{M2_HOME}" ]; then
   export MVN_EXEC="mvn"
 else
   export MVN_EXEC="${symbol_dollar}{M2_HOME}/bin/mvn"

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -44,6 +44,7 @@ IF %1==build_test (
     CALL :build
     CALL :start
     CALL :test
+    CALL :tail_all
     CALL :down
     GOTO END
 )
@@ -80,6 +81,9 @@ EXIT /B 0
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
+EXIT /B 0
+:tail_all
+    docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
     call mvn verify

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -79,13 +79,13 @@ EXIT /B 0
 :build
     docker rmi alfresco-content-services-${rootArtifactId}:development
     docker rmi alfresco-share-${rootArtifactId}:development
-	call "%MVN_EXEC%" clean install -DskipTests
+	call %MVN_EXEC% clean install -DskipTests
 EXIT /B 0
 :build_share
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-share
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-	call "%MVN_EXEC%" clean install -DskipTests
+	call %MVN_EXEC% clean install -DskipTests
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
@@ -94,7 +94,7 @@ EXIT /B 0
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
-    call "%MVN_EXEC%" verify
+    call %MVN_EXEC% verify
 EXIT /B 0
 :purge
     docker volume rm ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -3,6 +3,14 @@
 
 SET COMPOSE_FILE_PATH=%CD%\target\classes\docker\docker-compose.yml
 
+IF [%M2_HOME%]==[] (
+    SET MVN_EXEC=mvn
+)
+
+IF NOT [%M2_HOME%]==[] (
+    SET MVN_EXEC=%M2_HOME%\bin\mvn
+)
+
 IF [%1]==[] (
     echo "Usage: %0 {build_start|start|stop|purge|tail|reload_share|build_test|test}"
     GOTO END
@@ -71,13 +79,13 @@ EXIT /B 0
 :build
     docker rmi alfresco-content-services-${rootArtifactId}:development
     docker rmi alfresco-share-${rootArtifactId}:development
-	call mvn clean install -DskipTests
+	call "%MVN_EXEC%" clean install -DskipTests
 EXIT /B 0
 :build_share
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-share
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-	call mvn clean install -DskipTests
+	call "%MVN_EXEC%" clean install -DskipTests
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
@@ -86,7 +94,7 @@ EXIT /B 0
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
 EXIT /B 0
 :test
-    call mvn verify
+    call "%MVN_EXEC%" verify
 EXIT /B 0
 :purge
     docker volume rm ${rootArtifactId}-acs-volume

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -40,6 +40,10 @@ tail() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs -f
 }
 
+tail_all() {
+    docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs --tail="all"
+}
+
 test() {
     mvn verify
 }
@@ -75,6 +79,7 @@ case "${symbol_dollar}1" in
     build
     start
     test
+    tail_all
     down
     ;;
   test)

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -3,7 +3,7 @@
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
 
-if [[ -z "${symbol_dollar}{M2_HOME}" ]]; then
+if [ -z "${symbol_dollar}{M2_HOME}" ]; then
   export MVN_EXEC="mvn"
 else
   export MVN_EXEC="${symbol_dollar}{M2_HOME}/bin/mvn"

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -3,6 +3,12 @@
 
 export COMPOSE_FILE_PATH=${symbol_dollar}{PWD}/target/classes/docker/docker-compose.yml
 
+if [[ -z "${symbol_dollar}{M2_HOME}" ]]; then
+  export MVN_EXEC="mvn"
+else
+  export MVN_EXEC="${symbol_dollar}{M2_HOME}/bin/mvn"
+fi
+
 start() {
     docker volume create ${rootArtifactId}-acs-volume
     docker volume create ${rootArtifactId}-db-volume
@@ -26,14 +32,14 @@ purge() {
 
 build() {
     docker rmi alfresco-share-${rootArtifactId}:development
-    mvn clean install -DskipTests=true
+    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true
 }
 
 build_share() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH kill ${rootArtifactId}-share
     yes | docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH rm -f ${rootArtifactId}-share
     docker rmi alfresco-share-${rootArtifactId}:development
-    mvn clean install -DskipTests=true
+    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true
 }
 
 tail() {
@@ -45,7 +51,7 @@ tail_all() {
 }
 
 test() {
-    mvn verify
+    ${symbol_dollar}MVN_EXEC verify
 }
 
 case "${symbol_dollar}1" in

--- a/archetypes/archetypes-it/pom.xml
+++ b/archetypes/archetypes-it/pom.xml
@@ -9,6 +9,12 @@
     <name>Archetypes IT</name>
     <description>Archetypes Integration Tests</description>
 
+    <properties>
+        <slf4j.version>1.7.12</slf4j.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
@@ -27,6 +33,18 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -55,6 +73,14 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <org.slf4j.simpleLogger.defaultLogLevel>DEBUG</org.slf4j.simpleLogger.defaultLogLevel>
+                        <org.slf4j.simpleLogger.showDateTime>false</org.slf4j.simpleLogger.showDateTime>
+                        <org.slf4j.simpleLogger.showThreadName>false</org.slf4j.simpleLogger.showThreadName>
+                        <org.slf4j.simpleLogger.showLogName>false</org.slf4j.simpleLogger.showLogName>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/AbstractArchetypeIT.java
+++ b/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/AbstractArchetypeIT.java
@@ -3,6 +3,8 @@ package org.alfresco.maven.archetype;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +15,8 @@ import java.io.IOException;
  * @author Jose Luis Osorno <joseluis.osorno@ixxus.com>
  */
 public abstract class AbstractArchetypeIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractArchetypeIT.class);
 
     protected static final File ROOT = new File("target/test-classes/");
     protected static final String LOG_FILENAME = "log.txt";
@@ -46,11 +50,16 @@ public abstract class AbstractArchetypeIT {
     /**
      * Generate a new project from an archetype and verify the generation was successful.
      */
-    protected void generateProjectFromArchetype() throws Exception {
+    protected void generateProjectFromArchetype(final Logger logger) throws Exception {
+        LOG.info("---------------------------------------------------------------------");
+        LOG.info("Generating a new project from the archetype {}:{}:{}", archetypeProperties.getArchetypeGroupId(), archetypeProperties.getArchetypeArtifactId(),
+                archetypeProperties.getArchetypeVersion());
+        LOG.info("---------------------------------------------------------------------");
         Verifier verifier = new Verifier(ROOT.getAbsolutePath());
         verifier.setSystemProperties(archetypeProperties.getSystemProperties());
         verifier.setAutoclean(false);
         verifier.executeGoal("archetype:generate");
+        printVerifierLog("PROJECT GENERATION", verifier, logger);
         verifier.verifyErrorFreeLog();
     }
 
@@ -62,10 +71,22 @@ public abstract class AbstractArchetypeIT {
      */
     protected ProcessBuilder getProcessBuilder(final String goalToExecute) {
         ProcessBuilder pb = new ProcessBuilder(getCommand(), goalToExecute);
+        LOG.info("ProcessBuilder environment: {}", pb.environment().toString());
         pb.directory(new File(projectPath));
         pb.redirectOutput(new File(projectPath + File.separator + LOG_FILENAME));
         pb.redirectError(new File(projectPath + File.separator + ERROR_FILENAME));
         return pb;
+    }
+
+    /**
+     * Print the content of the log file of a {@link Verifier} into a specific {@link Logger}.
+     *
+     * @param prefix the prefix to print before each line
+     * @param verifier the {@link Verifier} to print its log file content
+     * @param logger the {@link Logger} to print the log content
+     */
+    protected void printVerifierLog(final String prefix, final Verifier verifier, final Logger logger) throws Exception {
+        verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false).forEach(line -> logger.info("[{}] - {}", prefix, line));
     }
 
     private String getCommand() {

--- a/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/AbstractArchetypeIT.java
+++ b/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/AbstractArchetypeIT.java
@@ -71,7 +71,7 @@ public abstract class AbstractArchetypeIT {
      */
     protected ProcessBuilder getProcessBuilder(final String goalToExecute) {
         ProcessBuilder pb = new ProcessBuilder(getCommand(), goalToExecute);
-        LOG.info("ProcessBuilder environment: {}", pb.environment().toString());
+        LOG.trace("ProcessBuilder environment: {}", pb.environment().toString());
         pb.directory(new File(projectPath));
         pb.redirectOutput(new File(projectPath + File.separator + LOG_FILENAME));
         pb.redirectError(new File(projectPath + File.separator + ERROR_FILENAME));

--- a/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/AllInOneArchetypeIT.java
+++ b/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/AllInOneArchetypeIT.java
@@ -2,11 +2,15 @@ package org.alfresco.maven.archetype;
 
 import org.apache.maven.it.Verifier;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests for the all-in-one archetype.
  */
 public class AllInOneArchetypeIT extends AbstractArchetypeIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AllInOneArchetypeIT.class);
 
     @Override
     protected ArchetypeProperties createArchetypeProperties() {
@@ -23,7 +27,11 @@ public class AllInOneArchetypeIT extends AbstractArchetypeIT {
     @Test
     public void whenGenerateProjectFromArchetypeThenAProperProjectIsCreated() throws Exception {
 
-        generateProjectFromArchetype();
+        generateProjectFromArchetype(LOGGER);
+
+        LOGGER.info("---------------------------------------------------------------------");
+        LOGGER.info("Building the generated project {}", archetypeProperties.getProjectArtifactId());
+        LOGGER.info("---------------------------------------------------------------------");
 
         // Since creating the archetype was successful, we now want to actually build the generated project executing the integration tests
         // Execute a purge to ensure old data don't make the test fail
@@ -36,6 +44,7 @@ public class AllInOneArchetypeIT extends AbstractArchetypeIT {
         Verifier verifier = new Verifier(projectPath);
         verifier.setAutoclean(false);
         verifier.setLogFileName(LOG_FILENAME);
+        printVerifierLog("PROJECT BUILD", verifier, LOGGER);
         verifier.verifyErrorFreeLog();
         verifier.verifyTextInLog("Tests run: 5, Failures: 0, Errors: 0, Skipped: 0");
     }

--- a/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/PlatformJarArchetypeIT.java
+++ b/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/PlatformJarArchetypeIT.java
@@ -2,11 +2,15 @@ package org.alfresco.maven.archetype;
 
 import org.apache.maven.it.Verifier;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests for the platform jar archetype.
  */
 public class PlatformJarArchetypeIT extends AbstractArchetypeIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformJarArchetypeIT.class);
 
     @Override
     protected ArchetypeProperties createArchetypeProperties() {
@@ -22,12 +26,17 @@ public class PlatformJarArchetypeIT extends AbstractArchetypeIT {
 
     @Test
     public void whenGenerateProjectFromArchetypeThenAProperProjectIsCreated() throws Exception {
-        generateProjectFromArchetype();
+        generateProjectFromArchetype(LOGGER);
+
+        LOGGER.info("---------------------------------------------------------------------");
+        LOGGER.info("Building the generated project {}", archetypeProperties.getProjectArtifactId());
+        LOGGER.info("---------------------------------------------------------------------");
 
         // Since creating the archetype was successful, we now want to actually build the generated project
         Verifier verifier = new Verifier(projectPath);
         verifier.setAutoclean(false);
         verifier.executeGoal("install");
+        printVerifierLog("PROJECT BUILD", verifier, LOGGER);
         verifier.verifyErrorFreeLog();
     }
 }

--- a/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/ShareJarArchetypeIT.java
+++ b/archetypes/archetypes-it/src/test/java/org/alfresco/maven/archetype/ShareJarArchetypeIT.java
@@ -2,11 +2,15 @@ package org.alfresco.maven.archetype;
 
 import org.apache.maven.it.Verifier;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests for the share jar archetype.
  */
 public class ShareJarArchetypeIT extends AbstractArchetypeIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShareJarArchetypeIT.class);
 
     @Override
     protected ArchetypeProperties createArchetypeProperties() {
@@ -22,12 +26,17 @@ public class ShareJarArchetypeIT extends AbstractArchetypeIT {
 
     @Test
     public void whenGenerateProjectFromArchetypeThenAProperProjectIsCreated() throws Exception {
-        generateProjectFromArchetype();
+        generateProjectFromArchetype(LOGGER);
+
+        LOGGER.info("---------------------------------------------------------------------");
+        LOGGER.info("Building the generated project {}", archetypeProperties.getProjectArtifactId());
+        LOGGER.info("---------------------------------------------------------------------");
 
         // Since creating the archetype was successful, we now want to actually build the generated project
         Verifier verifier = new Verifier(projectPath);
         verifier.setAutoclean(false);
         verifier.executeGoal("install");
+        printVerifierLog("PROJECT BUILD", verifier, LOGGER);
         verifier.verifyErrorFreeLog();
     }
 }


### PR DESCRIPTION
- Configure SLF4J in archetypes-it to show more detail in the console about the execution of the archetypes' integration tests.
- Change the bash/batch scripts to try to locate the `mvn` executable though the environment variable `M2_HOME`. If the variable is set, use it as `M2_HOME/bin/mvn`, if not simply use `mvn`.