### PR TITLE
BUGFIX - MNT-19097 - Ensure unmount war files

### DIFF
--- a/plugins/alfresco-maven-plugin/pom.xml
+++ b/plugins/alfresco-maven-plugin/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>zt-zip</artifactId>
             <version>1.11</version>
         </dependency>
+        <dependency>
+            <groupId>de.schlichtherle.truezip</groupId>
+            <artifactId>truezip-kernel</artifactId>
+            <version>7.7.9</version>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
+++ b/plugins/alfresco-maven-plugin/src/main/java/org/alfresco/maven/plugin/AbstractRunMojo.java
@@ -17,6 +17,8 @@
  */
 package org.alfresco.maven.plugin;
 
+import de.schlichtherle.truezip.file.TVFS;
+import de.schlichtherle.truezip.fs.FsSyncException;
 import org.alfresco.maven.plugin.config.ModuleDependency;
 import org.alfresco.maven.plugin.config.TomcatDependency;
 import org.alfresco.maven.plugin.config.TomcatWebapp;
@@ -1176,6 +1178,13 @@ public abstract class AbstractRunMojo extends AbstractMojo {
                     ),
                     execEnv
             );
+        }
+
+        // Force the unmount of all the files mounted with TrueZIP to avoid an exception in the FsSyncShutdownHook
+        try {
+            TVFS.umount();
+        } catch (final FsSyncException e) {
+            getLog().error(e);
         }
     }
 


### PR DESCRIPTION
Ensure the unmount of the war files in the alfresco maven plugin to avoid
the exception thrown by the FsSyncShutdownHook.