### PR TITLE
BUGFIX - 498 - Archetypes - Add module-specific log4j.properties to AMPs

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-jar/src/main/assembly/amp.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-jar/src/main/assembly/amp.xml
@@ -35,6 +35,11 @@
             <source>src/main/assembly/file-mapping.properties</source>
             <filtered>false</filtered>
         </file>
+        <!-- Add module-specific log4j.properties configuration at top level in the AMP -->
+        <file>
+            <source>src/main/resources/alfresco/module/${project.artifactId}/log4j.properties</source>
+            <filtered>false</filtered>
+        </file>
     </files>
 
     <fileSets>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-jar/src/main/resources/alfresco/module/__artifactId__/log4j.properties
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-jar/src/main/resources/alfresco/module/__artifactId__/log4j.properties
@@ -1,0 +1,1 @@
+# Add here module-specific custom log4j.properties configuration

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share-jar/src/main/assembly/amp.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share-jar/src/main/assembly/amp.xml
@@ -35,6 +35,11 @@
             <source>src/main/assembly/file-mapping.properties</source>
             <filtered>false</filtered>
         </file>
+        <!-- Add module-specific log4j.properties configuration at top level in the AMP -->
+        <file>
+            <source>src/main/resources/alfresco/module/${project.artifactId}/log4j.properties</source>
+            <filtered>false</filtered>
+        </file>
     </files>
 
     <fileSets>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share-jar/src/main/resources/alfresco/module/__rootArtifactId__-share-jar/log4j.properties
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share-jar/src/main/resources/alfresco/module/__rootArtifactId__-share-jar/log4j.properties
@@ -1,0 +1,1 @@
+# Add here module-specific custom log4j.properties configuration

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/assembly/amp.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/assembly/amp.xml
@@ -35,6 +35,11 @@
             <source>src/main/assembly/file-mapping.properties</source>
             <filtered>false</filtered>
         </file>
+        <!-- Add module-specific log4j.properties configuration at top level in the AMP -->
+        <file>
+            <source>src/main/resources/alfresco/module/${project.artifactId}/log4j.properties</source>
+            <filtered>false</filtered>
+        </file>
     </files>
 
     <fileSets>

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/resources/alfresco/module/__artifactId__/log4j.properties
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/resources/alfresco/module/__artifactId__/log4j.properties
@@ -1,0 +1,1 @@
+# Add here module-specific custom log4j.properties configuration

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/src/main/assembly/amp.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/src/main/assembly/amp.xml
@@ -35,6 +35,11 @@
             <source>src/main/assembly/file-mapping.properties</source>
             <filtered>false</filtered>
         </file>
+        <!-- Add module-specific log4j.properties configuration at top level in the AMP -->
+        <file>
+            <source>src/main/resources/alfresco/module/${project.artifactId}/log4j.properties</source>
+            <filtered>false</filtered>
+        </file>
     </files>
 
     <fileSets>

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/src/main/resources/alfresco/module/__artifactId__/log4j.properties
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/src/main/resources/alfresco/module/__artifactId__/log4j.properties
@@ -1,0 +1,1 @@
+# Add here module-specific custom log4j.properties configuration


### PR DESCRIPTION
Add module-specific log4j.properties files to the archetypes and modify the assembly
files to include them in the AMPs. This way, it is possible to add custom log
configuration for each developed module.

#498 