### PR TITLE
BUGFIX - 457 - Archetypes - Modify IT company home assertion

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/integration-tests/src/test/java/platformsample/DemoComponentIT.java
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/integration-tests/src/test/java/platformsample/DemoComponentIT.java
@@ -55,10 +55,9 @@ public class DemoComponentIT extends AbstractAlfrescoIT {
         DemoComponent demoComponent = (DemoComponent) getApplicationContext().getBean("${package}.DemoComponent");
         NodeRef companyHome = demoComponent.getCompanyHome();
         assertNotNull(companyHome);
-        String companyHomeName = (String) getServiceRegistry().getNodeService().getProperty(
-                companyHome, ContentModel.PROP_NAME);
-        assertNotNull(companyHomeName);
-        assertEquals("Company Home", companyHomeName);
+        String companyHomePath = getServiceRegistry().getNodeService().getPath(companyHome).toPrefixString(getServiceRegistry().getNamespaceService());
+        assertNotNull(companyHomePath);
+        assertEquals("/app:company_home", companyHomePath);
     }
 
     @Test


### PR DESCRIPTION
Modity the assertion about the name of the company home node in the
integration test DemoComponentIT to avoid issues with the language
in which the Alfresco environment is installed. It asserts now
about the path of the node which is independant from the language
of the application.

#457 