### PR TITLE
BUGFIX - Archetypes - Remove redundant license fileSet

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -119,12 +119,6 @@
                 dir="__rootArtifactId__-platform-docker">
             <fileSets>
                 <fileSet encoding="UTF-8" filtered="false">
-                    <directory>src/main/docker/license</directory>
-                    <includes>
-                        <include>**</include>
-                    </includes>
-                </fileSet>
-                <fileSet encoding="UTF-8" filtered="false">
                     <directory>src/main/docker</directory>
                     <includes>
                         <include>license/**</include>

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -24,12 +24,6 @@
             </includes>
         </fileSet>
         <fileSet encoding="UTF-8" filtered="false">
-            <directory>src/main/docker/license</directory>
-            <includes>
-                <include>**</include>
-            </includes>
-        </fileSet>
-        <fileSet encoding="UTF-8" filtered="false">
             <directory>src/main/docker</directory>
             <includes>
                 <include>license/**</include>


### PR DESCRIPTION
Modify the AIO and platform-jar archetypes to remove a redundant fileSet for the license folder.

#535 