### PR TITLE
Archetypes - Update module dependency version

### DIFF
--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -212,7 +212,7 @@
                                 <artifactItem>
                                     <groupId>${groupId}</groupId>
                                     <artifactId>${artifactId}</artifactId>
-                                    <version>${version}</version>
+                                    <version>${project.version}</version>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/extensions</outputDirectory>
                                 </artifactItem>
@@ -221,7 +221,7 @@
                                 <artifactItem>
                                     <groupId>${groupId}</groupId>
                                     <artifactId>${artifactId}</artifactId>
-                                    <version>${version}</version>
+                                    <version>${project.version}</version>
                                     <classifier>tests</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/extensions</outputDirectory>

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -220,7 +220,7 @@
                 <executions>
                     <!-- Copy the share extension -->
                     <execution>
-                        <id>copy-repo-extension</id>
+                        <id>copy-share-extension</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>copy</goal>
@@ -230,7 +230,7 @@
                                 <artifactItem>
                                     <groupId>${groupId}</groupId>
                                     <artifactId>${artifactId}</artifactId>
-                                    <version>${version}</version>
+                                    <version>${project.version}</version>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/extensions</outputDirectory>
                                 </artifactItem>


### PR DESCRIPTION
Change the module dependency version to `${project.version}` to avoid issues updating the project version and forgetting the update in the dependencies.

Created from PR https://github.com/Alfresco/alfresco-sdk/pull/550 to apply it to the last version of the archetype (it includes new tests dependency in the platform module).

Thanks @douglascrp !

#548 #549 