### PR TITLE
Archetypes - Add build with IT supported task

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/README.md
@@ -14,6 +14,8 @@ All the services of the project are now run as docker containers. The run script
 
  * `build_start`. Build the whole project, recreate the ACS and Share docker images, start the dockerised environment composed by ACS, Share, ASS and 
  PostgreSQL and tail the logs of all the containers.
+ * `build_start_it_supported`. Build the whole project including dependencies required for IT execution, recreate the ACS and Share docker images, start the 
+ dockerised environment composed by ACS, Share, ASS and PostgreSQL and tail the logs of all the containers.
  * `start`. Start the dockerised environment without building the project and tail the logs of all the containers.
  * `stop`. Stop the dockerised environment.
  * `purge`. Stop the dockerised container and delete all the persistent data (docker volumes).

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
@@ -12,13 +12,21 @@ IF NOT [%M2_HOME%]==[] (
 )
 
 IF [%1]==[] (
-    echo "Usage: %0 {build_start|start|stop|purge|tail|reload_share|reload_acs|build_test|test}"
+    echo "Usage: %0 {build_start|build_start_it_supported|start|stop|purge|tail|reload_share|reload_acs|build_test|test}"
     GOTO END
 )
 
 IF %1==build_start (
     CALL :down
     CALL :build
+    CALL :start
+    CALL :tail
+    GOTO END
+)
+IF %1==build_start_it_supported (
+    CALL :down
+    CALL :build
+    CALL :prepare-test
     CALL :start
     CALL :tail
     GOTO END

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -75,6 +75,13 @@ case "${symbol_dollar}1" in
     start
     tail
     ;;
+  build_start_it_supported)
+    down
+    build
+    prepare_test
+    start
+    tail
+    ;;
   start)
     start
     tail
@@ -112,5 +119,5 @@ case "${symbol_dollar}1" in
     test
     ;;
   *)
-    echo "Usage: ${symbol_dollar}0 {build_start|start|stop|purge|tail|reload_share|reload_acs|build_test|test}"
+    echo "Usage: ${symbol_dollar}0 {build_start|build_start_it_supported|start|stop|purge|tail|reload_share|reload_acs|build_test|test}"
 esac

--- a/docs/advanced-topics/integration-testing/it-running.md
+++ b/docs/advanced-topics/integration-testing/it-running.md
@@ -20,7 +20,7 @@ $ ./run.sh build_test
 ```
 
 If you want all your previous data in the docker environment to be wiped out before the execution of the integration tests, remember to call the `purge` goal
-before the `build_start` goal:
+before the `build_test` goal:
 
 ```
 $ ./run.sh purge
@@ -69,8 +69,8 @@ If your project is available in Eclipse, you can easily run one or more of the i
 
 To run the integration tests:
 
-1. In order to properly execute the integration tests the dockerised environment must be already up and running. So, before executing the tests you must run
-the `build_start` or the `start` goal of the `run` script.
+1. In order to properly execute the integration tests the dockerised environment must be already up and running with IT support. So, before executing the tests 
+you must run the `build_start_it_supported` or the `start` goal of the `run` script.
 
 2. Open the project using the IDE.
 
@@ -95,8 +95,8 @@ If your project is available in IntelliJ IDEA, you can easily run one or more of
 
 To run the integration tests:
 
-1. In order to properly execute the integration tests the dockerised environment must be already up and running. So, before executing the tests you must run
-the `build_start` or the `start` goal of the `run` script.
+1. In order to properly execute the integration tests the dockerised environment must be already up and running with IT support. So, before executing the tests 
+you must run the `build_start_it_supported` or the `start` goal of the `run` script.
 
 2. Open the project using the IDE.
 

--- a/docs/working-with-generated-projects/README.md
+++ b/docs/working-with-generated-projects/README.md
@@ -37,6 +37,7 @@ The execution of this script must be followed by a parameter that dictates the t
 Task | Description
 --- | ---
 `build_start` | Build the whole project, recreate the ACS and Share docker images, start the dockerised environment composed by ACS, Share, ASS and PostgreSQL and tail the logs of all the containers.
+`build_start_it_supported` | Build the whole project including dependencies required for IT execution, recreate the ACS and Share docker images, start the dockerised environment composed by ACS, Share, ASS and PostgreSQL and tail the logs of all the containers.
 `start` | Start the dockerised environment without building the project and tail the logs of all the containers.
 `stop` | Stop the dockerised environment.
 `purge` | Stop the dockerised environment and delete all the persistent data (docker volumes).


### PR DESCRIPTION
Modify the run scripts to add the task: `build_start_it_supported`. 

After the last changes regarding the way the project is compiled and retrieves the IT dependencies, it lost the ability to run the project in docker with IT support (including the libraries required to execute IT) but without executing the tests. It only had `build_start` (no IT supported) and `build_test` (IT supported but started and stopped the environment after IT execution).

This new task allows the execution of the docker environment with IT execution supported to cover the next use cases:
- Running IT classes from IDE (for instance, to debug the execution).
- Running IT classes with hot reload enabled.