### PR TITLE
Archetypes - Make ACS containers optional in share archetype

### DIFF
--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -8,61 +8,62 @@ services:
       context: ../../../target
     environment:
       CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8888"
-      REPO_HOST: ${rootArtifactId}-acs
-      REPO_PORT: 8080
+      REPO_HOST: ${symbol_dollar}{acs.host}
+      REPO_PORT: ${symbol_dollar}{acs.port}
     ports:
       - "${symbol_dollar}{share.port}:8080"
       - "${symbol_dollar}{share.debug.port}:8888"
-  ${rootArtifactId}-acs:
-    image: ${symbol_dollar}{docker.acs.image}:${symbol_dollar}{alfresco.platform.version}
-    environment:
-      JAVA_OPTS: "
-                -Ddb.driver=org.postgresql.Driver
-                -Ddb.username=alfresco
-                -Ddb.password=alfresco
-                -Ddb.url=jdbc:postgresql://${rootArtifactId}-postgres:5432/alfresco
-                -Dsolr.host=${rootArtifactId}-ass
-                -Dsolr.port=8983
-                -Dsolr.secureComms=none
-                -Dsolr.base.url=/solr
-                -Dindex.subsystem.name=solr6
-                -Dcsrf.filter.enabled=false
-                -Dmessaging.broker.url=\"vm://localhost?broker.persistent=false\"
-                "
-    ports:
-      - "${symbol_dollar}{acs.port}:8080"
-    volumes:
-      - ${rootArtifactId}-acs-volume:/usr/local/tomcat/alf_data
-    depends_on:
-      - ${rootArtifactId}-postgres
-  ${rootArtifactId}-postgres:
-    image: postgres:9.6
-    environment:
-      POSTGRES_DB: alfresco
-      POSTGRES_USER: alfresco
-      POSTGRES_PASSWORD: alfresco
-    command: postgres -c max_connections=300 -c log_min_messages=LOG
-    ports:
-      - "${symbol_dollar}{postgres.port}:5432"
-    volumes:
-      - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
-  ${rootArtifactId}-ass:
-    image: alfresco/alfresco-search-services:1.2.0
-    environment:
-      SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
-      SOLR_ALFRESCO_PORT: 8080
-      SOLR_SOLR_HOST: ${rootArtifactId}-ass
-      SOLR_SOLR_PORT: 8983
-      SOLR_CREATE_ALFRESCO_DEFAULTS: alfresco,archive
-    ports:
-      - "8983:8983"
-    volumes:
-      - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/contentstore
-      - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/data
-volumes:
-  ${rootArtifactId}-acs-volume:
-    external: true
-  ${rootArtifactId}-db-volume:
-    external: true
-  ${rootArtifactId}-ass-volume:
-    external: true
+# Optional
+#  ${rootArtifactId}-acs:
+#    image: ${symbol_dollar}{docker.acs.image}:${symbol_dollar}{alfresco.platform.version}
+#    environment:
+#      JAVA_OPTS: "
+#                -Ddb.driver=org.postgresql.Driver
+#                -Ddb.username=alfresco
+#                -Ddb.password=alfresco
+#                -Ddb.url=jdbc:postgresql://${rootArtifactId}-postgres:5432/alfresco
+#                -Dsolr.host=${rootArtifactId}-ass
+#                -Dsolr.port=8983
+#                -Dsolr.secureComms=none
+#                -Dsolr.base.url=/solr
+#                -Dindex.subsystem.name=solr6
+#                -Dcsrf.filter.enabled=false
+#                -Dmessaging.broker.url=\"vm://localhost?broker.persistent=false\"
+#                "
+#    ports:
+#      - "${symbol_dollar}{acs.port}:8080"
+#    volumes:
+#      - ${rootArtifactId}-acs-volume:/usr/local/tomcat/alf_data
+#    depends_on:
+#      - ${rootArtifactId}-postgres
+#  ${rootArtifactId}-postgres:
+#    image: postgres:9.6
+#    environment:
+#      POSTGRES_DB: alfresco
+#      POSTGRES_USER: alfresco
+#      POSTGRES_PASSWORD: alfresco
+#    command: postgres -c max_connections=300 -c log_min_messages=LOG
+#    ports:
+#      - "${symbol_dollar}{postgres.port}:5432"
+#    volumes:
+#      - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
+#  ${rootArtifactId}-ass:
+#    image: alfresco/alfresco-search-services:1.2.0
+#    environment:
+#      SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
+#      SOLR_ALFRESCO_PORT: 8080
+#      SOLR_SOLR_HOST: ${rootArtifactId}-ass
+#      SOLR_SOLR_PORT: 8983
+#      SOLR_CREATE_ALFRESCO_DEFAULTS: alfresco,archive
+#    ports:
+#      - "8983:8983"
+#    volumes:
+#      - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/contentstore
+#      - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/data
+#volumes:
+#  ${rootArtifactId}-acs-volume:
+#    external: true
+#  ${rootArtifactId}-db-volume:
+#    external: true
+#  ${rootArtifactId}-ass-volume:
+#    external: true


### PR DESCRIPTION
Modify the `docker-compose.yml` file of the share-jar archetype in order to comment out the unnecessary containers (ACS, ASS, DB). They're optional and can be used simply removing the comments.

Created from https://github.com/Alfresco/alfresco-sdk/pull/552 to solve the conflicts. 

Thanks @douglascrp!

#551 