### PR TITLE
Archetypes - Update Alfresco 6.1 versions

### DIFF
--- a/docs/advanced-topics/switching-versions.md
+++ b/docs/advanced-topics/switching-versions.md
@@ -15,10 +15,9 @@ to use.
 When editing `pom.xml` you will see a number of properties that define the Alfresco Content Services platform version and the Alfresco Share version, such as:
 
 ```
-<alfresco.platform.version>6.0.7-ga</alfresco.platform.version>
-<alfresco.share.version>6.0.c</alfresco.share.version>
+<alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
+<alfresco.share.version>6.1.0-RC3</alfresco.share.version>
 ```
-**(confirmation required)**
 
 Before continuing, always remember to start from a newly generated SDK project before changing the version numbers. We do not recommend changing the versions 
 using developed customizations or source code.

--- a/docs/advanced-topics/working-with-enterprise/README.md
+++ b/docs/advanced-topics/working-with-enterprise/README.md
@@ -54,10 +54,9 @@ The configuration of the Enterprise version is straightforward when using the `p
 You'll need to update the following settings in the `pom.xml` file:
 
 ```
-<alfresco.platform.version>6.0.0.2</alfresco.platform.version>
-<alfresco.share.version>6.0</alfresco.share.version>
+<alfresco.platform.version>6.1.0</alfresco.platform.version>
+<alfresco.share.version>6.1.0</alfresco.share.version>
 ```
-**(confirmation required)**
 
 Making use of the Alfresco SDK 4.0 it is no longer required the configuration of the Alfresco Surf versions. The inclusion of the BOM and the custom Docker
 images will take care of that task automatically for you.

--- a/modules/alfresco-rad/pom.xml
+++ b/modules/alfresco-rad/pom.xml
@@ -14,12 +14,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.alfresco</groupId>
+                <artifactId>${alfresco.bomDependency.artifactId}</artifactId>
+                <version>${alfresco.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Access to org.alfresco.service.ServiceRegistry -->
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
-            <version>${alfresco.community.default.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -35,6 +46,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,6 @@
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
 
-        <!-- The following version is needed for alfresco-rad -->
-        <alfresco.community.default.version>5.2.f</alfresco.community.default.version>
-        <alfresco.enterprise.default.version>5.2.0</alfresco.enterprise.default.version>
-        <alfresco.sdk.default.edition>community</alfresco.sdk.default.edition>
-
         <test.acs.endpoint.path />
 
         <scm.url.base>https://github.com/Alfresco/alfresco-sdk</scm.url.base>

--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,8 @@
         <alfresco.sdk.tests.exclude>*/*-enterprise*/*</alfresco.sdk.tests.exclude>
 
         <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-        <alfresco.platform.version>6.0.7-ga</alfresco.platform.version>
-        <alfresco.share.version>6.0.b</alfresco.share.version>
+        <alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
+        <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
 
@@ -298,6 +298,18 @@
             </distributionManagement>
         </profile>
 
+        <!-- 6.0 -->
+        <profile>
+            <id>community-60-tests</id>
+            <properties>
+                <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
+                <alfresco.platform.version>6.0.7-ga</alfresco.platform.version>
+                <alfresco.share.version>6.0.b</alfresco.share.version>
+                <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+            </properties>
+        </profile>
+
         <profile>
             <id>enterprise-60-tests</id>
             <properties>
@@ -309,13 +321,14 @@
             </properties>
         </profile>
 
+        <!-- 6.1 -->
         <!-- This profile requires to be executed using Java 11 -->
         <profile>
             <id>enterprise-61-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>6.1.0-RC4</alfresco.platform.version>
-                <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
+                <alfresco.platform.version>6.1.0</alfresco.platform.version>
+                <alfresco.share.version>6.1.0</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
             </properties>


### PR DESCRIPTION
Update Alfresco 6.1 version numbers.

**Community**
* ACS - 6.1.2-ga
* Share - 6.1.0-RC3

**Enterprise**
* ACS - 6.1.0
* Share - 6.1.0