### PR TITLE
Archetypes - Compile IT module to avoid fail reload ACS

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.bat
@@ -107,7 +107,7 @@ EXIT /B 0
 :build_acs
     docker-compose -f "%COMPOSE_FILE_PATH%" kill ${rootArtifactId}-acs
     docker-compose -f "%COMPOSE_FILE_PATH%" rm -f ${rootArtifactId}-acs
-	call %MVN_EXEC% clean package -pl ${rootArtifactId}-platform,${rootArtifactId}-platform-docker
+	call %MVN_EXEC% clean package -pl ${rootArtifactId}-integration-tests,${rootArtifactId}-platform,${rootArtifactId}-platform-docker
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/run.sh
@@ -49,7 +49,7 @@ build_share() {
 build_acs() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH kill ${rootArtifactId}-acs
     yes | docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH rm -f ${rootArtifactId}-acs
-    ${symbol_dollar}MVN_EXEC clean package -pl ${rootArtifactId}-platform,${rootArtifactId}-platform-docker
+    ${symbol_dollar}MVN_EXEC clean package -pl ${rootArtifactId}-integration-tests,${rootArtifactId}-platform,${rootArtifactId}-platform-docker
 }
 
 tail() {


### PR DESCRIPTION
Add the compilation of the IT maven module to the reload_acs script task to avoid a compilation failure if this module is not compiled in this task.