### PR TITLE
Archetypes - Change platform archetype build approach

### DIFF
--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/README.md
@@ -14,6 +14,8 @@ All the services of the project are now run as docker containers. The run script
 
  * `build_start`. Build the whole project, recreate the ACS docker image, start the dockerised environment composed by ACS, Share (optional), ASS 
  and PostgreSQL and tail the logs of all the containers.
+ * `build_start_it_supported`. Build the whole project including dependencies required for IT execution, recreate the ACS docker image, start the dockerised environment 
+ composed by ACS, Share (optional), ASS and PostgreSQL and tail the logs of all the containers.
  * `start`. Start the dockerised environment without building the project and tail the logs of all the containers.
  * `stop`. Stop the dockerised environment.
  * `purge`. Stop the dockerised container and delete all the persistent data (docker volumes).

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -192,6 +192,44 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-repository-extension</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/extensions</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>${build.finalName}.jar</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-repository-tests</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/extensions</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>${build.finalName}-tests.jar</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -200,73 +238,29 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.1.1</version>
                 <executions>
-                    <!-- Copy the repository extension and the dependencies required for execute integration tests -->
+                    <!-- Copy the dependencies required for execute integration tests -->
                     <execution>
-                        <id>copy-repo-extension</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${groupId}</groupId>
-                                    <artifactId>${artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                                </artifactItem>
-                                <!-- Test dependencies -->
-                                <!-- We need these dependencies installed in ACS in order to execute the test remotely making use of the Alfresco RAD module -->
-                                <artifactItem>
-                                    <groupId>${groupId}</groupId>
-                                    <artifactId>${artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <classifier>tests</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.alfresco.maven</groupId>
-                                    <artifactId>alfresco-rad</artifactId>
-                                    <version>${alfresco.sdk.version}</version>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>junit</groupId>
-                                    <artifactId>junit</artifactId>
-                                    <version>4.12</version>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.mockito</groupId>
-                                    <artifactId>mockito-all</artifactId>
-                                    <version>1.9.5</version>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.httpcomponents</groupId>
-                                    <artifactId>httpclient</artifactId>
-                                    <version>4.5.2</version>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                    <!-- Copy other dependencies (JARs or AMPs) declared in the platform module -->
-                    <execution>
-                        <id>copy-third-party-dependencies</id>
+                        <id>collect-test-artifacts</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/extensions</outputDirectory>
+                            <excludeScope>compile</excludeScope>
+                        </configuration>
+                    </execution>
+                    <!-- Collect extensions (JARs or AMPs) declared in this module to be deployed to docker -->
+                    <execution>
+                        <id>collect-extensions</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/extensions</outputDirectory>
                             <includeScope>runtime</includeScope>
+                            <!-- IMPORTANT: if using amp dependencies only, add <includeTypes>amp</includeTypes> -->
                         </configuration>
                     </execution>
                 </executions>

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -98,6 +98,41 @@
 
     <build>
         <plugins>
+            <!--
+                    Build an AMP if 3rd party libs are needed by the extensions
+                    JARs are the default artifact produced in your modules, if you want to build an amp for each module
+                    you have to enable this plugin and inspect the src/main/assembly.xml file if you want to customize
+                    the layout of your AMP. The end result is that Maven will produce both a JAR file and an AMP with your
+                    module.
+                -->
+            <!--
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>build-amp-file</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptor>src/main/assembly/amp.xml</descriptor>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.alfresco.maven.plugin</groupId>
+                        <artifactId>alfresco-maven-plugin</artifactId>
+                        <version>${alfresco.sdk.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            -->
+
             <!-- Filter the test resource files in the AIO parent project, and do property substitutions.
                  We need this config so this is done before the Alfresco Maven Plugin 'run' is executed. -->
             <plugin>
@@ -365,41 +400,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!--
-                    Build an AMP if 3rd party libs are needed by the extensions
-                    JARs are the default artifact produced in your modules, if you want to build an amp for each module
-                    you have to enable this plugin and inspect the src/main/assembly.xml file if you want to customize
-                    the layout of your AMP. The end result is that Maven will produce both a JAR file and an AMP with your
-                    module.
-                -->
-            <!--
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <id>build-amp-file</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <descriptor>src/main/assembly/amp.xml</descriptor>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.alfresco.maven.plugin</groupId>
-                        <artifactId>alfresco-maven-plugin</artifactId>
-                        <version>${alfresco.sdk.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            -->
 
             <!-- Hot reloading with JRebel -->
             <plugin>

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.bat
@@ -12,13 +12,21 @@ IF NOT [%M2_HOME%]==[] (
 )
 
 IF [%1]==[] (
-    echo "Usage: %0 {build_start|start|stop|purge|tail|build_test|test}"
+    echo "Usage: %0 {build_start|build_start_it_supported|start|stop|purge|tail|build_test|test}"
     GOTO END
 )
 
 IF %1==build_start (
     CALL :down
     CALL :build
+    CALL :start
+    CALL :tail
+    GOTO END
+)
+IF %1==build_start_it_supported (
+    CALL :down
+    CALL :build
+    CALL :prepare_test
     CALL :start
     CALL :tail
     GOTO END
@@ -44,6 +52,7 @@ IF %1==tail (
 IF %1==build_test (
     CALL :down
     CALL :build
+    CALL :prepare_test
     CALL :start
     CALL :test
     CALL :tail_all
@@ -70,13 +79,16 @@ EXIT /B 0
     )
 EXIT /B 0
 :build
-	call %MVN_EXEC% clean install -DskipTests
+	call %MVN_EXEC% clean package
 EXIT /B 0
 :tail
     docker-compose -f "%COMPOSE_FILE_PATH%" logs -f
 EXIT /B 0
 :tail_all
     docker-compose -f "%COMPOSE_FILE_PATH%" logs --tail="all"
+EXIT /B 0
+:prepare_test
+    call %MVN_EXEC% verify -DskipTests=true
 EXIT /B 0
 :test
     call %MVN_EXEC% verify

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/run.sh
@@ -29,7 +29,7 @@ purge() {
 }
 
 build() {
-    ${symbol_dollar}MVN_EXEC clean install -DskipTests=true
+    ${symbol_dollar}MVN_EXEC clean package
 }
 
 tail() {
@@ -40,6 +40,10 @@ tail_all() {
     docker-compose -f ${symbol_dollar}COMPOSE_FILE_PATH logs --tail="all"
 }
 
+prepare_test() {
+    ${symbol_dollar}MVN_EXEC verify -DskipTests=true
+}
+
 test() {
     ${symbol_dollar}MVN_EXEC verify
 }
@@ -48,6 +52,13 @@ case "${symbol_dollar}1" in
   build_start)
     down
     build
+    start
+    tail
+    ;;
+  build_start_it_supported)
+    down
+    build
+    prepare_test
     start
     tail
     ;;
@@ -68,6 +79,7 @@ case "${symbol_dollar}1" in
   build_test)
     down
     build
+    prepare_test
     start
     test
     tail_all
@@ -77,5 +89,5 @@ case "${symbol_dollar}1" in
     test
     ;;
   *)
-    echo "Usage: ${symbol_dollar}0 {build_start|start|stop|purge|tail|build_test|test}"
+    echo "Usage: ${symbol_dollar}0 {build_start|build_start_it_supported|start|stop|purge|tail|build_test|test}"
 esac

--- a/docs/advanced-topics/amps.md
+++ b/docs/advanced-topics/amps.md
@@ -95,39 +95,28 @@ do is modify the `pom.xml` file of the corresponding docker module / project in 
 
 ### Platform / Share project
 
-1. Modify the Maven Dependency Plugin in the file `pom.xml` to set the platform / share JAR dependency type to `amp`:
+1. Modify the Maven Resource Plugin in the file `pom.xml` to set the platform / share JAR artifact to copy to `amp`:
 
 ```
-<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-dependency-plugin</artifactId>
-    <executions>
-        <!-- Copy the repository extension and the dependencies required for execute integration tests -->
-        <execution>
-            <id>copy-repo-extension</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-                <goal>copy</goal>
-            </goals>
-            <configuration>
-                <artifactItems>
-                    <artifactItem>
-                        <groupId>org.alfresco</groupId>
-                        <artifactId>sample-platform-jar</artifactId>
-                        <version>1.0-SNAPSHOT</version>
-                        <overWrite>false</overWrite>
-                        <outputDirectory>${project.build.directory}/extensions</outputDirectory>
-                        <type>amp</type>
-                    </artifactItem>
-                    <!-- Test dependencies -->
-                    ...
-                </artifactItems>
-            </configuration>
-        </execution>
-        <!-- Copy other dependencies (JARs or AMPs) declared in the platform module -->
-        ...
-    </executions>
-</plugin>
+<execution>
+    <id>copy-repository-extension</id>
+    <phase>package</phase>
+    <goals>
+        <goal>copy-resources</goal>
+    </goals>
+    <configuration>
+        <outputDirectory>${project.build.directory}/extensions</outputDirectory>
+        <resources>
+            <resource>
+                <directory>target</directory>
+                <includes>
+                    <include>${build.finalName}.amp</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </configuration>
+</execution>
 ```
 
 Once this configuration is in place, you simply need to rebuild and restart the project. The new configuration will make the Docker images automatically 


### PR DESCRIPTION
- Build the project using package goal instead of install
- Copy the test dependencies only when IT is executed
- Add the build_start_it_supported task to execution scripts