### PR TITLE
Fix for issue 566

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/src/main/docker/Dockerfile
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/src/main/docker/Dockerfile
@@ -10,7 +10,9 @@ COPY Dockerfile extensions/*.amp $TOMCAT_DIR/amps/
 RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt*.jar install \
               $TOMCAT_DIR/amps $TOMCAT_DIR/webapps/alfresco -directory -nobackup -force
 
-COPY alfresco-global.properties $TOMCAT_DIR/shared/classes/alfresco-global.properties
+COPY alfresco-global.properties $TOMCAT_DIR/shared/classes/alfresco-global-dev.properties
+RUN mv $TOMCAT_DIR/shared/classes/alfresco-global.properties $TOMCAT_DIR/shared/classes/alfresco-global-orig.properties \
+   && awk -F= '!a[$1]++' $TOMCAT_DIR/shared/classes/alfresco-global-dev.properties $TOMCAT_DIR/shared/classes/alfresco-global-orig.properties > $TOMCAT_DIR/shared/classes/alfresco-global.properties
 COPY dev-log4j.properties $TOMCAT_DIR/shared/classes/alfresco/extension
 COPY disable-webscript-caching-context.xml $TOMCAT_DIR/shared/classes/alfresco/extension
 

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/docker/Dockerfile
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/docker/Dockerfile
@@ -10,7 +10,9 @@ COPY Dockerfile extensions/*.amp $TOMCAT_DIR/amps/
 RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt*.jar install \
               $TOMCAT_DIR/amps $TOMCAT_DIR/webapps/alfresco -directory -nobackup -force
 
-COPY alfresco-global.properties $TOMCAT_DIR/shared/classes/alfresco-global.properties
+COPY alfresco-global.properties $TOMCAT_DIR/shared/classes/alfresco-global-dev.properties
+RUN mv $TOMCAT_DIR/shared/classes/alfresco-global.properties $TOMCAT_DIR/shared/classes/alfresco-global-orig.properties \
+   && awk -F= '!a[$1]++' $TOMCAT_DIR/shared/classes/alfresco-global-dev.properties $TOMCAT_DIR/shared/classes/alfresco-global-orig.properties > $TOMCAT_DIR/shared/classes/alfresco-global.properties
 COPY dev-log4j.properties $TOMCAT_DIR/shared/classes/alfresco/extension
 COPY disable-webscript-caching-context.xml $TOMCAT_DIR/shared/classes/alfresco/extension
 


### PR DESCRIPTION
I came across issue #566 and wanted to share our solution.

Instead of replacing the default file shipped with ACS image, we merged both files, so Alfresco can decide where to install libreoffice, imagemagick and pdf-renderer, while we keep our beatiful alfresco-global.properties file. 
We only set in environment section of docker-compose those properties that can be changed across dev/pre/pro environments, like hosts and ports.

Hope this helps.
