### PR TITLE
fixed deprecated valiable.

### DIFF
--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -239,7 +239,7 @@
                                 <resource>
                                     <directory>target</directory>
                                     <includes>
-                                        <include>${build.finalName}.jar</include>
+                                        <include>${project.build.finalName}.jar</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>
@@ -258,7 +258,7 @@
                                 <resource>
                                     <directory>target</directory>
                                     <includes>
-                                        <include>${build.finalName}-tests.jar</include>
+                                        <include>${project.build.finalName}-tests.jar</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -207,7 +207,7 @@
                                 <resource>
                                     <directory>target</directory>
                                     <includes>
-                                        <include>${build.finalName}.jar</include>
+                                        <include>${project.build.finalName}.jar</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>


### PR DESCRIPTION
#578

I fixed three deprecated valiables because the following error was displayed when building.

```
[WARNING] The expression ${build.finalName} is deprecated. Please use ${project.build.finalName} instead.
```

Hope this helps.