### PR TITLE
Archetypes - Add support for ACS 6.2

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/src/main/docker/Dockerfile
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/src/main/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM ${docker.acs.image}:${alfresco.platform.version}
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 
+USER root
+
 # Copy Dockerfile to avoid an error if no JARs exist
 COPY Dockerfile extensions/*.jar $TOMCAT_DIR/webapps/alfresco/WEB-INF/lib/
 
@@ -16,3 +18,5 @@ COPY disable-webscript-caching-context.xml $TOMCAT_DIR/shared/classes/alfresco/e
 
 # Copy Dockerfile to avoid an error if no license file exists
 COPY Dockerfile license/*.* $TOMCAT_DIR/webapps/alfresco/WEB-INF/classes/alfresco/extension/license/
+
+USER ${USERNAME}

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/src/main/docker/alfresco-global.properties
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/src/main/docker/alfresco-global.properties
@@ -80,3 +80,8 @@ csrf.filter.enabled=false
 
 # Embedded broker without persistence
 messaging.broker.url=vm://localhost?broker.persistent=false
+
+# Disable ATS
+transform.service.enabled=false
+local.transform.service.enabled=false
+legacy.transform.service.enabled=false

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/docker/Dockerfile
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM ${docker.acs.image}:${alfresco.platform.version}
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 
+USER root
+
 # Copy Dockerfile to avoid an error if no JARs exist
 COPY Dockerfile extensions/*.jar $TOMCAT_DIR/webapps/alfresco/WEB-INF/lib/
 
@@ -16,3 +18,5 @@ COPY disable-webscript-caching-context.xml $TOMCAT_DIR/shared/classes/alfresco/e
 
 # Copy Dockerfile to avoid an error if no license file exists
 COPY Dockerfile license/*.* $TOMCAT_DIR/webapps/alfresco/WEB-INF/classes/alfresco/extension/license/
+
+USER ${USERNAME}

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/docker/alfresco-global.properties
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/src/main/docker/alfresco-global.properties
@@ -80,3 +80,8 @@ csrf.filter.enabled=false
 
 # Embedded broker without persistence
 messaging.broker.url=vm://localhost?broker.persistent=false
+
+# Disable ATS
+transform.service.enabled=false
+local.transform.service.enabled=false
+legacy.transform.service.enabled=false

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -29,6 +29,9 @@ services:
 #                -Dindex.subsystem.name=solr6
 #                -Dcsrf.filter.enabled=false
 #                -Dmessaging.broker.url=\"vm://localhost?broker.persistent=false\"
+#                -Dtransform.service.enabled=false
+#                -Dlocal.transform.service.enabled=false
+#                -Dlegacy.transform.service.enabled=false
 #                "
 #    ports:
 #      - "${symbol_dollar}{acs.port}:8080"

--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,8 @@
         <alfresco.sdk.tests.exclude>*/*-enterprise*/*</alfresco.sdk.tests.exclude>
 
         <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-        <alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
-        <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
+        <alfresco.platform.version>6.2.0-A9</alfresco.platform.version>
+        <alfresco.share.version>6.2.0-RC2</alfresco.share.version>
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
 
@@ -319,11 +319,46 @@
         <!-- 6.1 -->
         <!-- This profile requires to be executed using Java 11 -->
         <profile>
+            <id>community-61-tests</id>
+            <properties>
+                <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
+                <alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
+                <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
+                <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+            </properties>
+        </profile>
+
+        <profile>
             <id>enterprise-61-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.1.0</alfresco.platform.version>
                 <alfresco.share.version>6.1.0</alfresco.share.version>
+                <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+            </properties>
+        </profile>
+
+        <!-- 6.2 -->
+        <!-- This profile requires to be executed using Java 11 -->
+        <profile>
+            <id>community-62-tests</id>
+            <properties>
+                <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
+                <alfresco.platform.version>6.2.0-A9</alfresco.platform.version>
+                <alfresco.share.version>6.2.0-RC2</alfresco.share.version>
+                <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>enterprise-62-tests</id>
+            <properties>
+                <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
+                <alfresco.platform.version>6.2.0-RC1</alfresco.platform.version>
+                <alfresco.share.version>6.2.0-RC1</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
             </properties>


### PR DESCRIPTION
- New alfresco community and enterprise 6.2.0 profiles
- Execute dockerfile as root to avoid issues applying AMPs
- Disable transformation service by default in archetypes