### PR TITLE
Archetypes - Fix deprecated use of maven project name

### DIFF
--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -239,7 +239,7 @@
                                 <resource>
                                     <directory>target</directory>
                                     <includes>
-                                        <include>${build.finalName}.jar</include>
+                                        <include>${project.build.finalName}.jar</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>
@@ -258,7 +258,7 @@
                                 <resource>
                                     <directory>target</directory>
                                     <includes>
-                                        <include>${build.finalName}-tests.jar</include>
+                                        <include>${project.build.finalName}-tests.jar</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -207,7 +207,7 @@
                                 <resource>
                                     <directory>target</directory>
                                     <includes>
-                                        <include>${build.finalName}.jar</include>
+                                        <include>${project.build.finalName}.jar</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>

--- a/docs/advanced-topics/amps.md
+++ b/docs/advanced-topics/amps.md
@@ -110,7 +110,7 @@ do is modify the `pom.xml` file of the corresponding docker module / project in 
             <resource>
                 <directory>target</directory>
                 <includes>
-                    <include>${build.finalName}.amp</include>
+                    <include>${project.build.finalName}.amp</include>
                 </includes>
                 <filtering>false</filtering>
             </resource>


### PR DESCRIPTION
Fix the use of the deprecated maven key ${build.finalName}. Using ${project.build.finalName}
instead.