### PR TITLE
To chooseable solr and database.

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - ${rootArtifactId}-postgres
   ${rootArtifactId}-postgres:
-    image: postgres:9.6
+    image: ${docker.db.image}:${alfresco.db.version}
     environment:
       POSTGRES_DB: alfresco
       POSTGRES_USER: alfresco
@@ -39,7 +39,7 @@ services:
     volumes:
       - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
   ${rootArtifactId}-ass:
-    image: alfresco/alfresco-search-services:1.2.0
+    image: ${docker.solr.image}:${alfresco.solr.version}
     environment:
       SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
       SOLR_ALFRESCO_PORT: 8080

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -24,10 +24,14 @@
         <alfresco.bomDependencyArtifactId>@@alfresco.bomDependency.artifactId@@</alfresco.bomDependencyArtifactId>
         <alfresco.platform.version>@@alfresco.platform.version@@</alfresco.platform.version>
         <alfresco.share.version>@@alfresco.share.version@@</alfresco.share.version>
+        <alfresco.solr.version>@@alfresco.solr.version@@</alfresco.solr.version>
+        <alfresco.db.version>@@alfresco.db.version@@</alfresco.db.version>
 
         <!-- Docker images -->
         <docker.acs.image>@@alfresco.platform.docker.image@@</docker.acs.image>
         <docker.share.image>@@alfresco.share.docker.image@@</docker.share.image>
+        <docker.solr.image>@@alfresco.solr.docker.image@@</docker.solr.image>
+        <docker.db.image>@@alfresco.db.docker.image@@</docker.db.image>
 
         <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
         <jrebel.version>1.1.8</jrebel.version>

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     depends_on:
       - ${rootArtifactId}-postgres
   ${rootArtifactId}-postgres:
-    image: postgres:9.6
+    image: ${docker.db.image}:${alfresco.db.version}
     environment:
       POSTGRES_DB: alfresco
       POSTGRES_USER: alfresco
@@ -35,7 +35,7 @@ services:
     volumes:
       - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
   ${rootArtifactId}-ass:
-    image: alfresco/alfresco-search-services:1.2.0
+    image: ${docker.solr.image}:${alfresco.solr.version}
     environment:
       SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
       SOLR_ALFRESCO_PORT: 8080

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,10 +20,14 @@
         <alfresco.bomDependencyArtifactId>@@alfresco.bomDependency.artifactId@@</alfresco.bomDependencyArtifactId>
         <alfresco.platform.version>@@alfresco.platform.version@@</alfresco.platform.version>
         <alfresco.share.version>@@alfresco.share.version@@</alfresco.share.version>
+        <alfresco.solr.version>@@alfresco.solr.version@@</alfresco.solr.version>
+        <alfresco.db.version>@@alfresco.db.version@@</alfresco.db.version>
 
         <!-- Docker images -->
         <docker.acs.image>@@alfresco.platform.docker.image@@</docker.acs.image>
         <docker.share.image>@@alfresco.share.docker.image@@</docker.share.image>
+        <docker.solr.image>@@alfresco.solr.docker.image@@</docker.solr.image>
+        <docker.db.image>@@alfresco.db.docker.image@@</docker.db.image>
 
         <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
         <jrebel.version>1.1.8</jrebel.version>

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 #    depends_on:
 #      - ${rootArtifactId}-postgres
 #  ${rootArtifactId}-postgres:
-#    image: postgres:9.6
+#    image: ${docker.db.image}:${alfresco.db.version}
 #    environment:
 #      POSTGRES_DB: alfresco
 #      POSTGRES_USER: alfresco
@@ -51,7 +51,7 @@ services:
 #    volumes:
 #      - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
 #  ${rootArtifactId}-ass:
-#    image: alfresco/alfresco-search-services:1.2.0
+#    image: ${docker.solr.image}:${alfresco.solr.version}
 #    environment:
 #      SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
 #      SOLR_ALFRESCO_PORT: 8080

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,10 +20,14 @@
         <alfresco.bomDependencyArtifactId>@@alfresco.bomDependency.artifactId@@</alfresco.bomDependencyArtifactId>
         <alfresco.platform.version>@@alfresco.platform.version@@</alfresco.platform.version>
         <alfresco.share.version>@@alfresco.share.version@@</alfresco.share.version>
+        <alfresco.solr.version>@@alfresco.solr.version@@</alfresco.solr.version>
+        <alfresco.db.version>@@alfresco.db.version@@</alfresco.db.version>
 
         <!-- Docker images -->
         <docker.acs.image>@@alfresco.platform.docker.image@@</docker.acs.image>
         <docker.share.image>@@alfresco.share.docker.image@@</docker.share.image>
+        <docker.solr.image>@@alfresco.solr.docker.image@@</docker.solr.image>
+        <docker.db.image>@@alfresco.db.docker.image@@</docker.db.image>
 
         <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
         <jrebel.version>1.1.8</jrebel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,10 +135,14 @@
         <alfresco.sdk.tests.exclude>*/*-enterprise*/*</alfresco.sdk.tests.exclude>
 
         <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-        <alfresco.platform.version>6.2.0-ea</alfresco.platform.version>
-        <alfresco.share.version>6.2.0</alfresco.share.version>
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+        <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+        <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
+        <alfresco.platform.version>6.2.0-ga</alfresco.platform.version>
+        <alfresco.share.version>6.2.0</alfresco.share.version>
+        <alfresco.solr.version>1.4.0</alfresco.solr.version>
+        <alfresco.db.version>11.4</alfresco.db.version>
 
         <test.acs.endpoint.path />
 
@@ -300,8 +304,12 @@
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.0.7-ga</alfresco.platform.version>
                 <alfresco.share.version>6.0.b</alfresco.share.version>
+                <alfresco.solr.version>1.4.0</alfresco.solr.version>
+                <alfresco.db.version>10.1</alfresco.db.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+                <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
             </properties>
         </profile>
 
@@ -311,8 +319,12 @@
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.0.0.2</alfresco.platform.version>
                 <alfresco.share.version>6.0</alfresco.share.version>
+                <alfresco.solr.version>1.4.0</alfresco.solr.version>
+                <alfresco.db.version>10.1</alfresco.db.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+                <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
             </properties>
         </profile>
 
@@ -324,8 +336,12 @@
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
                 <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
+                <alfresco.solr.version>1.4.0</alfresco.solr.version>
+                <alfresco.db.version>11.4</alfresco.db.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+                <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
             </properties>
         </profile>
 
@@ -333,10 +349,14 @@
             <id>enterprise-61-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>6.1.0</alfresco.platform.version>
+                <alfresco.platform.version>6.1.1</alfresco.platform.version>
                 <alfresco.share.version>6.1.0</alfresco.share.version>
+                <alfresco.solr.version>1.4.0</alfresco.solr.version>
+                <alfresco.db.version>11.4</alfresco.db.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+                <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
             </properties>
         </profile>
 
@@ -346,10 +366,14 @@
             <id>community-62-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>6.2.0-ea</alfresco.platform.version>
+                <alfresco.platform.version>6.2.0-ga</alfresco.platform.version>
                 <alfresco.share.version>6.2.0</alfresco.share.version>
+                <alfresco.solr.version>1.4.0</alfresco.solr.version>
+                <alfresco.db.version>11.4</alfresco.db.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+                <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
             </properties>
         </profile>
 
@@ -359,8 +383,12 @@
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.2.0</alfresco.platform.version>
                 <alfresco.share.version>6.2.0</alfresco.share.version>
+                <alfresco.solr.version>1.4.0</alfresco.solr.version>
+                <alfresco.db.version>11.4</alfresco.db.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.solr.docker.image>alfresco/alfresco-search-services</alfresco.solr.docker.image>
+                <alfresco.db.docker.image>postgres</alfresco.db.docker.image>
             </properties>
         </profile>
 


### PR DESCRIPTION
Hi.

Search Services and Database depend on the version of Alfresco Content Services used.
Therefore, it has been modified so that it can be selected.

How is it?