### PR TITLE
Suppress warnings (since Maven 3.5)

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -9,10 +9,6 @@
     <description>All-In-One (AIO) project for SDK 4.0</description>
     <packaging>pom</packaging>
 
-    <prerequisites>
-        <maven>3.3.0</maven>
-    </prerequisites>
-
     <properties>
         <!-- Alfresco Maven Plugin version to use -->
         <alfresco.sdk.version>@@alfresco.sdk.parent.version@@</alfresco.sdk.version>
@@ -243,6 +239,11 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -255,6 +256,25 @@
         </resources>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.3.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Filter the test resource files in the AIO parent project, and do property substitutions.
                  We need this config so this is done before the Alfresco Maven Plugin 'run' is executed. -->
             <plugin>


### PR DESCRIPTION
Hi.

Since Maven 3.5.0, it seems to be a way to specify Maven version using `maven-enforcer-plugin`, so it was fixed.

How is it?

References
- [Release Notes – Maven 3.5.0](https://maven.apache.org/docs/3.5.0/release-notes.html)
- [Require Maven Version](https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html)