### PR TITLE
File encoding is needed.

### DIFF
--- a/archetypes/archetypes-it/pom.xml
+++ b/archetypes/archetypes-it/pom.xml
@@ -12,6 +12,7 @@
         <slf4j.version>1.7.12</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <parent>


### PR DESCRIPTION
Hi.

The encoding of File was environment-dependent, so it was fixed to use `UTF-8`.

How is it?

Reference
- [Handle special characters in site](http://maven.apache.org/general.html#special-characters-site)