### PR TITLE
SDK 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ branches:
     - /feature\/.*/
     - /fix\/.*/
     - sdk-4.2
-    - /dev\/sdk-4.2-keystore/
 
 stages:
   - name: test
@@ -30,7 +29,7 @@ env:
 jobs:
   include:
   
-    - name: "default version"
+    - name: "current version"
       stage: test
       script: 
         - ${MAVEN_INSTALL_CMD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
     - master
     - /feature\/.*/
     - /fix\/.*/
+    - sdk-4.2
 
 stages:
   - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 import:
+  - source: Alfresco/alfresco-build-tools:.travis.docker_login.yml@v1.0.1
   - source: Alfresco/alfresco-build-tools:.travis.java.yml@v1.0.1
+  - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.0.1
 
 dist: focal
 
@@ -13,6 +15,7 @@ branches:
     - /feature\/.*/
     - /fix\/.*/
     - sdk-4.2
+    - /dev\/sdk-4.2-keystore/
 
 stages:
   - name: test
@@ -23,7 +26,7 @@ stages:
 env:
   global:
     - MAVEN_INSTALL_CMD="mvn clean install -B"
-    
+
 jobs:
   include:
   
@@ -32,6 +35,16 @@ jobs:
       script: 
         - ${MAVEN_INSTALL_CMD}
     
+    - name: "7.0 Enterprise"
+      stage: test
+      script:
+        - ${MAVEN_INSTALL_CMD} -Penterprise-70-tests
+    
+    - name: "7.0 Community"
+      stage: test
+      script:
+        - ${MAVEN_INSTALL_CMD} -Pcommunity-70-tests
+
     - name: "6.2 Enterprise"
       stage: test
       script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # [![Alfresco SDK logo](https://github.com/Alfresco/alfresco-sdk/raw/master/src/site/resources/img/alfresco-maven-logo.jpg)](#features) Alfresco SDK
 
+
+[![Build Status](https://travis-ci.com/Alfresco/alfresco-sdk.svg?branch=master)](https://travis-ci.com/Alfresco/alfresco-sdk)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+![GitHub](https://img.shields.io/github/license/Alfresco/alfresco-sdk?color=brightgreen)
+
 This is the home of the Alfresco SDK. The Alfresco SDK is used by developers to build extensions for the Alfresco Digital Business Platform. It is based on 
 [Apache Maven](http://maven.apache.org/), compatible with major IDEs and enables [Rapid Application Development (RAD)](https://en.wikipedia.org/wiki/Rapid_application_development) 
 and [Test Driven Development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development).
@@ -10,6 +15,7 @@ If you are an Enterprise customer check the [Support](#alfresco-enterprise-custo
 
 ## News
 
+- 2020-02: Alfresco SDK 4.2.0 released
 - 2019-10: Alfresco SDK 4.1.0 released
 - 2019-03: Alfresco SDK 4.0.0 released
 - 2019-03: Alfresco SDK 3.1.0 released
@@ -31,7 +37,8 @@ To get started with **Alfresco SDK 4.2.x** (latest) visit the [Alfresco Document
 #### Documentation about Previous Versions
 | SDK Version  | Alfresco Enterprise Version       |  Alfresco Community Version       | Documentation  |
 | ------------- |:-------------:| :-----:|:-----|
-| SDK 4.1   | Alfresco 6.0.x / 6.1.x / 6.2.x | Alfresco 6.0.x / 6.1.x / 6.2.x | https://github.com/Alfresco/alfresco-sdk/tree/master/docs/README.md |
+| SDK 4.2   | Alfresco 6.0.x / 6.1.x / 6.2.x / 7.0.x | Alfresco 6.0.x / 6.1.x / 6.2.x / 7.0.x | https://github.com/Alfresco/alfresco-sdk/tree/master/docs/README.md |
+| SDK 4.1   | Alfresco 6.0.x / 6.1.x / 6.2.x | Alfresco 6.0.x / 6.1.x / 6.2.x | https://github.com/Alfresco/alfresco-sdk/blob/sdk-4.1/docs/README.md |
 | SDK 4.0   | Alfresco 6.0.x / 6.1.x | Alfresco 6.0.x / 6.1.x | https://github.com/Alfresco/alfresco-sdk/blob/sdk-4.0/docs/README.md |
 | SDK 3.1   | Alfresco 5.2.x | Alfresco 5.2.x | http://docs.alfresco.com/5.2/concepts/sdk-intro.html |
 | SDK 3.0   | Alfresco 5.2.x | Alfresco 5.2.x | http://docs.alfresco.com/5.2/concepts/sdk-intro.html |

--- a/README.md
+++ b/README.md
@@ -31,13 +31,32 @@ If you are an Enterprise customer check the [Support](#alfresco-enterprise-custo
 
 ## User Getting Started
 
+### Important Notice about Version Numbers
+
+In Q4 2020, Alfresco Platform has undergone a major structural refactoring.
+
+Depending on the Platform version desired, you might need to use SDK 4.1 instead of SDK 4.2.
+
+- For Enterprise and Community versions of 7.x, SDK 4.2 must be used
+- For Enterprise versions of 6.0.x, 6.1.x, 6.2.x newer than November 2020, SDK 4.2 must be used
+- For Enterprise and Community versions of 6.0.x, 6.1.x, 6.2.x older than November 2020, SDK 4.1 must be used
+
+A more precise compatibility matrix, with specific version numbers, is expected to be provided soon.
+
+It's also important to remember that:
+
+- Community Platform versions are built by [acs-community-packaging](https://github.com/Alfresco/acs-community-packaging)
+- Community Docker images are published on [Docker Hub](https://hub.docker.com/r/alfresco/alfresco-content-repository-community/tags?page=1&ordering=last_updated)
+- Enterprise Platform versions are built by [acs-packaging](https://github.com/Alfresco/acs-packaging)
+- Enterprise Docker images are published on *Quay.io*
+
 ### Latest Documentation
 To get started with **Alfresco SDK 4.2.x** (latest) visit the [Alfresco Documentation](docs/README.md).
 
 #### Documentation about Previous Versions
 | SDK Version  | Alfresco Enterprise Version       |  Alfresco Community Version       | Documentation  |
 | ------------- |:-------------:| :-----:|:-----|
-| SDK 4.2   | Alfresco 6.0.x / 6.1.x / 6.2.x / 7.0.x | Alfresco 6.0.x / 6.1.x / 6.2.x / 7.0.x | https://github.com/Alfresco/alfresco-sdk/tree/master/docs/README.md |
+| SDK 4.2   | Alfresco 6.0.x / 6.1.x / 6.2.x / 7.0.x | Alfresco 7.0.x | https://github.com/Alfresco/alfresco-sdk/tree/master/docs/README.md |
 | SDK 4.1   | Alfresco 6.0.x / 6.1.x / 6.2.x | Alfresco 6.0.x / 6.1.x / 6.2.x | https://github.com/Alfresco/alfresco-sdk/blob/sdk-4.1/docs/README.md |
 | SDK 4.0   | Alfresco 6.0.x / 6.1.x | Alfresco 6.0.x / 6.1.x | https://github.com/Alfresco/alfresco-sdk/blob/sdk-4.0/docs/README.md |
 | SDK 3.1   | Alfresco 5.2.x | Alfresco 5.2.x | http://docs.alfresco.com/5.2/concepts/sdk-intro.html |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are an Enterprise customer check the [Support](#alfresco-enterprise-custo
 
 ## News
 
-- 2020-02: Alfresco SDK 4.2.0 released
+- 2021-02: Alfresco SDK 4.2.0 released
 - 2019-10: Alfresco SDK 4.1.0 released
 - 2019-03: Alfresco SDK 4.0.0 released
 - 2019-03: Alfresco SDK 3.1.0 released

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are an Enterprise customer check the [Support](#alfresco-enterprise-custo
 ## User Getting Started
 
 ### Latest Documentation
-To get started with **Alfresco SDK 4.1.x** (latest) visit the [Alfresco Documentation](docs/README.md).
+To get started with **Alfresco SDK 4.2.x** (latest) visit the [Alfresco Documentation](docs/README.md).
 
 #### Documentation about Previous Versions
 | SDK Version  | Alfresco Enterprise Version       |  Alfresco Community Version       | Documentation  |

--- a/archetypes/alfresco-allinone-archetype/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.alfresco.maven</groupId>
     <artifactId>alfresco-sdk-aggregator</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/README.md
@@ -1,6 +1,6 @@
-# Alfresco AIO Project - SDK 4.0
+# Alfresco AIO Project - SDK 4.2
 
-This is an All-In-One (AIO) project for Alfresco SDK 4.0.
+This is an All-In-One (AIO) project for Alfresco SDK 4.2.
 
 Run with `./run.sh build_start` or `./run.bat build_start` and verify that it
 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-integration-tests/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>${artifactId}</artifactId>
     <name>Integration Tests Module</name>
-    <description>Integration Tests module for in-container integration testing - part of AIO - SDK 4.0</description>
+    <description>Integration Tests module for in-container integration testing - part of AIO - SDK 4.2</description>
     <packaging>jar</packaging> <!-- Note. this just runs Integration Tests, but it needs to be a JAR otherwise
                                             nothing is compiled (i.e. you cannot set it to pom) -->
 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>${artifactId}</artifactId>
     <name>Alfresco Platform/Repository JAR Module</name>
-    <description>Platform/Repo JAR Module (to be included in the alfresco.war) - part of AIO - SDK 4.0
+    <description>Platform/Repo JAR Module (to be included in the alfresco.war) - part of AIO - SDK 4.2
     </description>
     <packaging>jar</packaging>
 

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-share/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>${artifactId}</artifactId>
     <name>Alfresco Share JAR Module</name>
     <packaging>jar</packaging>
-    <description>Sample Share JAR Module (to be included in the share.war) - part of AIO - SDK 4.0</description>
+    <description>Sample Share JAR Module (to be included in the share.war) - part of AIO - SDK 4.2</description>
 
     <parent>
         <groupId>${groupId}</groupId>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -19,6 +19,15 @@ services:
       dockerfile: ./Dockerfile
       context: ../../../${rootArtifactId}-platform-docker/target
     environment:
+      JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=AES
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
+        -Dmetadata-keystore.password=mp6yc0UD9e
+        -Dmetadata-keystore.aliases=metadata
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=AES"
       CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8888"
     ports:
       - "${symbol_dollar}{acs.port}:8080"

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -19,15 +19,7 @@ services:
       dockerfile: ./Dockerfile
       context: ../../../${rootArtifactId}-platform-docker/target
     environment:
-      JAVA_TOOL_OPTIONS: "
-        -Dencryption.keystore.type=JCEKS
-        -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
-        -Dencryption.keyAlgorithm=AES
-        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
-        -Dmetadata-keystore.password=mp6yc0UD9e
-        -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
-        -Dmetadata-keystore.metadata.algorithm=AES"
+      JAVA_TOOL_OPTIONS: "${symbol_dollar}{keystore.settings}"
       CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8888"
     ports:
       - "${symbol_dollar}{acs.port}:8080"

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,8 +5,8 @@
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
-    <name>AIO - SDK 4.0</name>
-    <description>All-In-One (AIO) project for SDK 4.0</description>
+    <name>AIO - SDK 4.2</name>
+    <description>All-In-One (AIO) project for SDK 4.2</description>
     <packaging>pom</packaging>
 
     <prerequisites>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,6 +29,8 @@
         <docker.acs.image>@@alfresco.platform.docker.image@@</docker.acs.image>
         <docker.share.image>@@alfresco.share.docker.image@@</docker.share.image>
 
+        <keystore.settings>@@keystore.settings@@</keystore.settings>
+
         <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
         <jrebel.version>1.1.8</jrebel.version>
 

--- a/archetypes/alfresco-platform-jar-archetype/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.alfresco.maven</groupId>
     <artifactId>alfresco-sdk-aggregator</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/README.md
@@ -1,6 +1,6 @@
-# Alfresco ACS JAR Module - SDK 4.0
+# Alfresco ACS JAR Module - SDK 4.2
 
-This is an ACS project for Alfresco SDK 4.0.
+This is an ACS project for Alfresco SDK 4.2.
 
 Run with `./run.sh build_start` or `./run.bat build_start` and verify that it
 

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -15,15 +15,7 @@ services:
       dockerfile: ./Dockerfile
       context: ../../../target
     environment:
-      JAVA_TOOL_OPTIONS: "
-        -Dencryption.keystore.type=JCEKS
-        -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
-        -Dencryption.keyAlgorithm=AES
-        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
-        -Dmetadata-keystore.password=mp6yc0UD9e
-        -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
-        -Dmetadata-keystore.metadata.algorithm=AES"
+      JAVA_TOOL_OPTIONS: "${symbol_dollar}{keystore.settings}"
       CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8888"
     ports:
       - "${symbol_dollar}{acs.port}:8080"

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -15,6 +15,15 @@ services:
       dockerfile: ./Dockerfile
       context: ../../../target
     environment:
+      JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=AES
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
+        -Dmetadata-keystore.password=mp6yc0UD9e
+        -Dmetadata-keystore.aliases=metadata
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=AES"
       CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8888"
     ports:
       - "${symbol_dollar}{acs.port}:8080"

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,6 +25,8 @@
         <docker.acs.image>@@alfresco.platform.docker.image@@</docker.acs.image>
         <docker.share.image>@@alfresco.share.docker.image@@</docker.share.image>
 
+        <keystore.settings>@@keystore.settings@@</keystore.settings>
+
         <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
         <jrebel.version>1.1.8</jrebel.version>
 

--- a/archetypes/alfresco-share-jar-archetype/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/README.md
@@ -1,6 +1,6 @@
-# Alfresco Share JAR Module - SDK 4.0
+# Alfresco Share JAR Module - SDK 4.2
 
-This is a Share project for Alfresco SDK 4.0.
+This is a Share project for Alfresco SDK 4.2.
 
 Run with `./run.sh build_start` or `./run.bat build_start` and verify that it
 

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -32,6 +32,7 @@ services:
 #                -Dtransform.service.enabled=false
 #                -Dlocal.transform.service.enabled=false
 #                -Dlegacy.transform.service.enabled=false
+#                ${symbol_dollar}{keystore.settings}
 #                "
 #    ports:
 #      - "${symbol_dollar}{acs.port}:8080"

--- a/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-share-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,6 +25,8 @@
         <docker.acs.image>@@alfresco.platform.docker.image@@</docker.acs.image>
         <docker.share.image>@@alfresco.share.docker.image@@</docker.share.image>
 
+        <keystore.settings>@@keystore.settings@@</keystore.settings>
+
         <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
         <jrebel.version>1.1.8</jrebel.version>
 

--- a/archetypes/archetypes-it/pom.xml
+++ b/archetypes/archetypes-it/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 Title: Alfresco SDK 4.2
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Alfresco SDK 4.2
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 ---
-Title: Alfresco SDK 4.1
+Title: Alfresco SDK 4.2
 Added: v3.0.0
 Last reviewed: 2019-10-18
 ---
-# Alfresco SDK 4.1
+# Alfresco SDK 4.2
 
-Alfresco SDK 4.1 is a Maven based development kit that provides an easy to use approach to developing applications and extensions for Alfresco. With this 
+Alfresco SDK 4.2 is a Maven based development kit that provides an easy to use approach to developing applications and extensions for Alfresco. With this 
 SDK you can develop, package, test, run, document and release your Alfresco extension project.
 
 For earlier releases of the Alfresco SDK, see the Previous versions of [http://docs.alfresco.com](http://docs.alfresco.com).
@@ -14,22 +14,22 @@ The Alfresco Software Development Kit (Alfresco SDK) is a fundamental tool provi
 the Alfresco Digital Business Platform. It is based on [Apache Maven](http://maven.apache.org/) and [Docker](https://www.docker.com/) and is compatible with 
 major IDEs. This enables Rapid Application Development (RAD) and Test Driven Development (TDD).
 
-Alfresco SDK 4.1 is released under [Apache License version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) and supports Alfresco Content Services both 
+Alfresco SDK 4.2 is released under [Apache License version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) and supports Alfresco Content Services both 
 in Community Edition and Enterprise Edition. If you're an Enterprise customer, please check the [Alfresco SDK Support status](https://www.alfresco.com/alfresco-product-support-status) 
 for the version you're using. If your version is in Limited or Full Support and you need help, contact our Support team [http://support.alfresco.com](http://support.alfresco.com/).
 
-Alfresco SDK 4.1 is a minor update to the SDK and provides support for Alfresco 6.2.x.
+Alfresco SDK 4.2 is a minor update to the SDK and provides support for Alfresco 7.0.x.
 
 The 4.0 release takes advantage of Semantic Versioning ([SEMVER](http://semver.org/)), which means that this new release is not directly compatible with the 
 previous releases of the SDK.
 
-If you have existing projects that you wish to upgrade to SDK 4.1.x, the recommended approach is to generate a new project from our archetypes and move your 
+If you have existing projects that you wish to upgrade to SDK 4.2.x, the recommended approach is to generate a new project from our archetypes and move your 
 code into place.
 
 ## Documentation Content
 
 * [What's new?](whats-new.md)
-* [Getting started with Alfresco SDK 4.1](getting-started.md)
+* [Getting started with Alfresco SDK 4.2](getting-started.md)
 * [Alfresco SDK Maven archetypes](mvn-archetypes.md)
 * [Working with generated projects](working-with-generated-projects/README.md)
     * [All-In-One project structure](working-with-generated-projects/structure-aio.md)

--- a/docs/advanced-topics/README.md
+++ b/docs/advanced-topics/README.md
@@ -1,7 +1,7 @@
 ---
 Title: Advanced topics
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Advanced topics
 

--- a/docs/advanced-topics/amps.md
+++ b/docs/advanced-topics/amps.md
@@ -5,7 +5,7 @@ Last reviewed: 2019-10-18
 ---
 # Working with AMPs
 
-Since the early days of the Alfresco SDK, the Alfresco Module Packages (AMP) have been the way customizations were packaged. In Alfresco SDK 4.1 everything 
+Since the early days of the Alfresco SDK, the Alfresco Module Packages (AMP) have been the way customizations were packaged. In Alfresco SDK 4.2 everything 
 is packaged as a JAR by default, while the AMPs are still available as an optional assembly. This gives you much more control over packaging, and simple 
 modules can easily be deployed as JARs.
 
@@ -55,7 +55,7 @@ to your needs.
 
 ## Installing AMPs with the SDK
 
-The projects created from the Alfresco SDK 4.1 archetypes are configured to deploy either JARs or AMPs to the ACS / Share docker container. The only thing to
+The projects created from the Alfresco SDK 4.2 archetypes are configured to deploy either JARs or AMPs to the ACS / Share docker container. The only thing to
 do is modify the `pom.xml` file of the corresponding docker module / project in order to properly configure the dependencies and the Maven dependency plugin.
 
 ### All-In-One project
@@ -237,7 +237,7 @@ include *.amp in the copy-and-filter-docker-resources-non-filtered
 ## Controlling the order AMPs are applied
 
 Under some specific circumstances it is necessary to apply different AMPs in a development project in a precise order. The default configuration of the 
-projects generated using the Alfresco SDK 4.1 archetypes doesn't specify any concrete order applying the AMPs to the ACS/Share installation.
+projects generated using the Alfresco SDK 4.2 archetypes doesn't specify any concrete order applying the AMPs to the ACS/Share installation.
 
 Anyway, that order can be controlled modifying slightly the configuration of the custom Docker images in the project. For instance, let's say we have three
 third party AMPs that we want to apply in the next order `third-party-amp-01.amp -> third-party-amp-02.amp -> third-party-amp-03.amp`. In this example, we're

--- a/docs/advanced-topics/amps.md
+++ b/docs/advanced-topics/amps.md
@@ -1,7 +1,7 @@
 ---
 Title: Working with AMPs
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Working with AMPs
 

--- a/docs/advanced-topics/debugging/README.md
+++ b/docs/advanced-topics/debugging/README.md
@@ -1,7 +1,7 @@
 ---
 Title: Debugging
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Debugging
 

--- a/docs/advanced-topics/debugging/README.md
+++ b/docs/advanced-topics/debugging/README.md
@@ -10,4 +10,4 @@ application server. This section outlines the steps needed to configure Alfresco
 and to troubleshoot issues by stepping through the code line by line.
 
 Here we assume you have already generated an Alfresco project using the Alfresco SDK. If you don't have a project already, follow the steps in 
-[Getting started with Alfresco SDK 4.1](../../getting-started.md) to learn how to generate it in a few easy steps.
+[Getting started with Alfresco SDK 4.2](../../getting-started.md) to learn how to generate it in a few easy steps.

--- a/docs/advanced-topics/debugging/debug-eclipse.md
+++ b/docs/advanced-topics/debugging/debug-eclipse.md
@@ -5,7 +5,7 @@ Last reviewed: 2019-10-18
 ---
 # Remote debugging using Eclipse
 
-All the projects generated using the Alfresco SDK 4.1 are pre-configured to listen for remote debug connections. Depending on the selected archetypes you'll 
+All the projects generated using the Alfresco SDK 4.2 are pre-configured to listen for remote debug connections. Depending on the selected archetypes you'll 
 have a port for remotely debugging ACS, share or both of them.
 
 By default, the remote debug port for ACS is **8888** and for share is **9898**. This configuration can be changed through the maven properties `acs.debug.port` 
@@ -79,7 +79,7 @@ application. In our case, we are going to test the behaviour of debugging by run
 
 8. Open your browser and type `http://localhost:8080/alfresco/s/sample/helloworld`.
 
-This is a sample webscript generated in every project created using SDK 4.1 and the platform artifact.
+This is a sample webscript generated in every project created using SDK 4.2 and the platform artifact.
 
 ![Alt text](../../docassets/images/sdk-hellofromjava.png "Hello World webscript original result")
 

--- a/docs/advanced-topics/debugging/debug-eclipse.md
+++ b/docs/advanced-topics/debugging/debug-eclipse.md
@@ -1,7 +1,7 @@
 ---
 Title: Remote debugging using Eclipse
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Remote debugging using Eclipse
 

--- a/docs/advanced-topics/debugging/debug-intellij.md
+++ b/docs/advanced-topics/debugging/debug-intellij.md
@@ -5,7 +5,7 @@ Last reviewed: 2019-10-18
 ---
 # Remote debugging using IntelliJ
 
-All the projects generated using the Alfresco SDK 4.1 are pre-configured to listen for remote debug connections. Depending on the selected archetypes you'll 
+All the projects generated using the Alfresco SDK 4.2 are pre-configured to listen for remote debug connections. Depending on the selected archetypes you'll 
 have a port for remotely debugging ACS, share or both of them.
 
 By default, the remote debug port for ACS is **8888** and for share is **9898**. This configuration can be changed through the maven properties `acs.debug.port` 
@@ -77,7 +77,7 @@ application. In our case, we are going to test the behaviour of debugging by run
 
 7. Open your browser and type `http://localhost:8080/alfresco/s/sample/helloworld`.
 
-This is a sample webscript generated in every project created using SDK 4.1 and the platform artifact.
+This is a sample webscript generated in every project created using SDK 4.2 and the platform artifact.
 
 ![Alt text](../../docassets/images/sdk-hellofromjava.png "Hello World webscript original result")
 

--- a/docs/advanced-topics/debugging/debug-intellij.md
+++ b/docs/advanced-topics/debugging/debug-intellij.md
@@ -1,7 +1,7 @@
 ---
 Title: Remote debugging using IntelliJ
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Remote debugging using IntelliJ
 

--- a/docs/advanced-topics/hot-reloading/hotswap-agent.md
+++ b/docs/advanced-topics/hot-reloading/hotswap-agent.md
@@ -8,7 +8,7 @@ Last reviewed: 2019-10-18
 [HotSwapAgent](http://hotswapagent.org/index.html) is the agent that enables you to do hot reloading. This allows you to modify the application code, and 
 view the changes without having to restart Alfresco Tomcat (or the ACS Docker container).
 
-A prerequisite for this tutorial is to have a project created with the Alfresco SDK 4.1, using the All-In-One archetype or the Platform JAR archetype. It's 
+A prerequisite for this tutorial is to have a project created with the Alfresco SDK 4.2, using the All-In-One archetype or the Platform JAR archetype. It's 
 worth noting that hot reloading is only supported on the platform, and not in Alfresco Share.
 
 As an alternative to the HotSwapAgent you can also try out JRebel. It has more features but isn't free.
@@ -112,7 +112,7 @@ For more information about HotSwapAgent configuration for Java 8, please check t
 Using Java 11 and HotSwapAgent, it isn't necessary to configure the java agent and the alternative JVM as in previous versions. Instead, it is required 
 to use an alternative pre-built JDK distribution. That JDK is based on OpenJDK and includes all the required modifications to run the HotSwapAgent properly.
 
-In the context of the Alfresco SDK 4.1, this change is an issue because the JDK installation is inherited from the [Alfresco java docker image](https://github.com/Alfresco/alfresco-docker-base-java). 
+In the context of the Alfresco SDK 4.2, this change is an issue because the JDK installation is inherited from the [Alfresco java docker image](https://github.com/Alfresco/alfresco-docker-base-java). 
 It is necessary to modify the project ACS docker image to change the default java installation of the container's OS to the one provided by HotSwapAgent.
 
 A way to implement the required modifications would be:
@@ -250,7 +250,7 @@ You'll recognize HotSwapAgent is working when you see similar log messages:
 
 2. Before making any changes, let's run the sample webscript by opening your browser and typing `http://localhost:8080/alfresco/s/sample/helloworld`.
 
-This is a sample webscript generated in every project created using SDK 4.1 and the platform artifact.
+This is a sample webscript generated in every project created using SDK 4.2 and the platform artifact.
 
 ![Alt text](../../docassets/images/sdk-hellofromjava.png "Hello World webscript original result")
 

--- a/docs/advanced-topics/hot-reloading/hotswap-agent.md
+++ b/docs/advanced-topics/hot-reloading/hotswap-agent.md
@@ -1,7 +1,7 @@
 ---
 Title: How to configure and use Hotswap Agent
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # How to configure and use Hotswap Agent
 

--- a/docs/advanced-topics/hot-reloading/jrebel.md
+++ b/docs/advanced-topics/hot-reloading/jrebel.md
@@ -8,7 +8,7 @@ Last reviewed: 2019-10-18
 [JRebel](https://zeroturnaround.com/software/jrebel/) is the agent that enables you to do hot reloading. This allows you to modify the application code, 
 and view the changes without having to restart Alfresco Tomcat (or the ACS Docker container).
 
-A prerequisite to this tutorial is having an Alfresco project created with Alfresco SDK 4.1, using the All-In-One archetype, or the Platform JAR archetype. 
+A prerequisite to this tutorial is having an Alfresco project created with Alfresco SDK 4.2, using the All-In-One archetype, or the Platform JAR archetype. 
 It's worth noting that hot reloading is only supported on the platform, and not in Alfresco Share.
 
 An open source and free of charge alternative to JRebel is HotSwapAgent. For more details, see the [HotSwapAgent website](http://hotswapagent.org/index.html).

--- a/docs/advanced-topics/integration-testing/README.md
+++ b/docs/advanced-topics/integration-testing/README.md
@@ -1,7 +1,7 @@
 ---
 Title: Integration testing
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Integration testing
 

--- a/docs/advanced-topics/integration-testing/README.md
+++ b/docs/advanced-topics/integration-testing/README.md
@@ -11,11 +11,11 @@ in an integration test plan to those aggregates, and delivers as its output the 
 
 Even if the definition of integration testing is a general description, the concept is also valid for Alfresco projects. 
 
-The Alfresco SDK 4.1 keeps the same general idea of integration testing provided by SDK 3.0, but this new version reshapes it slightly to leverage on a 
+The Alfresco SDK 4.2 keeps the same general idea of integration testing provided by SDK 3.0, but this new version reshapes it slightly to leverage on a 
 Docker-oriented environment.
 
 Here are the basics to understanding and using integration testing in the context of projects created with the SDK, from a technical perspective:
-* SDK 4.1 develops integration tests for the platform only. Currently, the integration tests that the SDK is able to manage by default is related to 
+* SDK 4.2 develops integration tests for the platform only. Currently, the integration tests that the SDK is able to manage by default is related to 
 Alfresco Content Services (ACS) only.
 * Integration tests require an ACS instance to be up and running. You will see that all the scripts and commands are designed to easily manage this 
 requirement, but the prerequisite for the SDK is that an ACS instance is available.

--- a/docs/advanced-topics/integration-testing/it-running.md
+++ b/docs/advanced-topics/integration-testing/it-running.md
@@ -1,7 +1,7 @@
 ---
 Title: How to run SDK's integration tests
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # How to run SDK's integration tests
 

--- a/docs/advanced-topics/integration-testing/it-running.md
+++ b/docs/advanced-topics/integration-testing/it-running.md
@@ -5,7 +5,7 @@ Last reviewed: 2019-10-18
 ---
 # How to run SDK's integration tests
 
-Running the integration tests of a project generated from the Alfresco SDK 4.1 archetypes is pretty easy. Let's distinguish different cases of executing the
+Running the integration tests of a project generated from the Alfresco SDK 4.2 archetypes is pretty easy. Let's distinguish different cases of executing the
 integration tests. 
 
 ## Command line

--- a/docs/advanced-topics/integration-testing/it-working.md
+++ b/docs/advanced-topics/integration-testing/it-working.md
@@ -36,7 +36,7 @@ or set the Java system property `acs.endpoint.path`.
 
 ## Integration tests configuration in the All-In-One project
 
-So, taking into account the previous section, let's see how the integration tests are configured in a project generated from the SDK 4.1 All-In-One archetype.
+So, taking into account the previous section, let's see how the integration tests are configured in a project generated from the SDK 4.2 All-In-One archetype.
 
 * The maven dependencies required to execute the integration tests are deployed to the ACS Docker image in the `PROJECT_ARTEFACTID-platform-docker` maven 
 module using the `maven-dependency-plugin`. The configuration is done in the file `PROJECT_ARTEFACTID-platform-docker/pom.xml`: 

--- a/docs/advanced-topics/switching-versions.md
+++ b/docs/advanced-topics/switching-versions.md
@@ -28,7 +28,7 @@ The supported versions are explained in the next sections of this article.
 
 ## Switch to Alfresco version 6.0.x
 
-Starting from a newly created Alfresco SDK 4.1 project (All-In-One, Platform JAR, or Share JAR), let’s replace the two properties with the following ones.
+Starting from a newly created Alfresco SDK 4.2 project (All-In-One, Platform JAR, or Share JAR), let’s replace the two properties with the following ones.
 
 1. Open the pom.xml in your generated project.
 
@@ -60,7 +60,7 @@ about wrong JDK versions.
 
 ## Switch to Alfresco version 6.1.x
 
-Starting from a newly created Alfresco SDK 4.1 project (All-In-One, Platform JAR, or Share JAR), let’s replace the two properties with the following ones.
+Starting from a newly created Alfresco SDK 4.2 project (All-In-One, Platform JAR, or Share JAR), let’s replace the two properties with the following ones.
 
 1. Open the pom.xml in your generated project.
 

--- a/docs/advanced-topics/switching-versions.md
+++ b/docs/advanced-topics/switching-versions.md
@@ -1,7 +1,7 @@
 ---
 Title: Switching Alfresco Content Services and Share versions
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Switching Alfresco Content Services and Share versions
 
@@ -15,8 +15,8 @@ to use.
 When editing `pom.xml` you will see a number of properties that define the Alfresco Content Services platform version and the Alfresco Share version, such as:
 
 ```
-<alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
-<alfresco.share.version>6.1.0-RC3</alfresco.share.version>
+<alfresco.platform.version>7.0.0-A20</alfresco.platform.version>
+<alfresco.share.version>7.0.0-M3</alfresco.share.version>
 ```
 
 Before continuing, always remember to start from a newly generated SDK project before changing the version numbers. We do not recommend changing the versions 
@@ -58,7 +58,7 @@ $ ./run.sh build_start
 switch from version 6.1+ to 6.0.x. If you compile Alfresco 6.0.x with JDK 11 you'll experience the issue described in the [Troubleshooting page](../troubleshooting.md) 
 about wrong JDK versions.
 
-## Switch to Alfresco version 6.1.x
+## Switch to Alfresco version 6.1.x or 6.2.x
 
 Starting from a newly created Alfresco SDK 4.2 project (All-In-One, Platform JAR, or Share JAR), let’s replace the two properties with the following ones.
 

--- a/docs/advanced-topics/upgrading.md
+++ b/docs/advanced-topics/upgrading.md
@@ -3,13 +3,13 @@ Title: Upgrading
 Added: v4.0.0
 Last reviewed: 2019-01-29
 ---
-# Upgrading an SDK 3.0 project to SDK 4.1
+# Upgrading an SDK 3.0 project to SDK 4.2
 
-In these instructions, "base" refers to a freshly instantiated SDK 4.1 and "target" refers to the SDK 3.0.1 project that is being upgraded.
+In these instructions, "base" refers to a freshly instantiated SDK 4.2 and "target" refers to the SDK 3.0.1 project that is being upgraded.
 
 ## Download a base
 
-Download or instantiate an SDK 4.1 project to use as a base for copying files.
+Download or instantiate an SDK 4.2 project to use as a base for copying files.
 
 For example, you might create a new project called `test-aio-400` to use as a base from which to copy files into the target project that is to be upgraded.
 
@@ -65,7 +65,7 @@ Similar to previous step, the directory should follow the same pattern as the ex
 
 Need to smartly do this merge so that target project maintains its dependencies, name, version, description, etc.
 
-1. Copy the entire `<properties>` element from the base 4.1 pom.xml into the target 3.0 pom.xml, replacing the existing one completely.
+1. Copy the entire `<properties>` element from the base 4.2 pom.xml into the target 3.0 pom.xml, replacing the existing one completely.
 
 2. Change the `acs.host` property to match the target project name.
 
@@ -220,7 +220,7 @@ Then that would need to be moved into the share docker module's pom.xml file in 
 
 ## Changes to the integration-tests module
 
-1. Completely replace the pom.xml file with the pom.xml file from the 4.1 pom.xml file under integration-tests.
+1. Completely replace the pom.xml file with the pom.xml file from the 4.2 pom.xml file under integration-tests.
 
 2. Edit the integration-tests pom.xml to replace references to the base project name with references to the target project name.
 
@@ -230,7 +230,7 @@ Then that would need to be moved into the share docker module's pom.xml file in 
 
 ## Changes to the platform-jar module
 
-Smartly merge the pom.xml file from the 4.1 platform-jar module into the existing platform-jar module pom.xml file.
+Smartly merge the pom.xml file from the 4.2 platform-jar module into the existing platform-jar module pom.xml file.
 
 Maintain the dependencies from the 3.0 platform-jar module pom.xml.
 
@@ -238,13 +238,13 @@ Any old "platformModule" dependencies, which are typically AMPs or JARs that nee
 
 ## Changes to the share-jar module
 
-Smartly merge the pom.xml file from the 4.1 share-jar module into the existing share-jar module pom.xml file.
+Smartly merge the pom.xml file from the 4.2 share-jar module into the existing share-jar module pom.xml file.
 
 Maintain the dependencies from the 3.0 share-jar module pom.xml.
 
 Any old "shareModule" dependencies, which are typically AMPs or JARs that need to be installed in the Share tier need to be copied into this pom.xml's depdencies.
 
-Remove the spring-surf-api dependency from the 4.1 share-jar module. Remove:
+Remove the spring-surf-api dependency from the 4.2 share-jar module. Remove:
 
 ```
 <dependency>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
 Title: Getting started with Alfresco SDK 4.2
 Added: v2.1.1
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Getting started with Alfresco SDK 4.2
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,15 +1,15 @@
 ---
-Title: Getting started with Alfresco SDK 4.1
+Title: Getting started with Alfresco SDK 4.2
 Added: v2.1.1
 Last reviewed: 2019-10-18
 ---
-# Getting started with Alfresco SDK 4.1
+# Getting started with Alfresco SDK 4.2
 
-Use these instructions to get started with using Alfresco SDK 4.1.
+Use these instructions to get started with using Alfresco SDK 4.2.
 
 ## Prerequisites
    
-There are a number of software requirements for using Alfresco SDK 4.1.
+There are a number of software requirements for using Alfresco SDK 4.2.
 * Java Development Kit (JDK) - Version 11
 * Maven - Version 3.3
 * Docker - Latest stable version
@@ -46,7 +46,7 @@ JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home
 Alfresco recommends that you keep up-to-date with all the Maven releases. Linux distributions and package managers tend to bundle older releases and this is 
 the most common pitfall.
 
-Alfresco SDK 4.1 requires Maven 3.3.0+, but you are recommended to download the latest version.
+Alfresco SDK 4.2 requires Maven 3.3.0+, but you are recommended to download the latest version.
 
 1. Download and install [Apache Maven](https://maven.apache.org/download.cgi) and make sure it is configured correctly on your path.
 
@@ -95,7 +95,7 @@ mvn archetype:generate -Dfilter=org.alfresco:
 ```
 
 You'll be prompted to select the archetype you want. The previously available archetypes, alfresco-amp-archetype and share-amp-archetype will still show up 
-as an option, however these archetypes are not part of Alfresco SDK 4.1.
+as an option, however these archetypes are not part of Alfresco SDK 4.2.
 
 Attention: You'll need double quotes around the filter part if you are using Windows Powershell: mvn archetype:generate "-Dfilter=org.alfresco:".
 
@@ -132,9 +132,11 @@ Choose org.alfresco.maven.archetype:alfresco-allinone-archetype version:
 8: 2.2.0
 9: 3.0.0
 10: 3.0.1
-11: 4.0.0
-12: 4.1.0
-13: 4.2.0
+11: 3.1.0
+12: 4.0.0-beta-1
+13: 4.0.0
+14: 4.1.0
+15: 4.2.0
 ```
 
 4. Next you will be prompted for additional values, like groupId, artifactId, and package, as shown below:
@@ -190,7 +192,7 @@ If everything has been configured correctly, you should see something similar to
 [INFO] ------------------------------------------------------------------------
 ```
 
-7. You have successfully generated your first SDK 4.1 project.
+7. You have successfully generated your first SDK 4.2 project.
 
 Inside the project, you will find the `run.bat` and `run.sh` scripts. These are convenience scripts for you to quickly compile / test / run your project.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,7 @@ Choose archetype:
 * `org.alfresco.maven.archetype:alfresco-platform-jar-archetype`
 * `org.alfresco.maven.archetype:alfresco-share-jar-archetype`
 
-3. Choose the latest version, such as 4.1.0.
+3. Choose the latest version, such as 4.2.0.
 
 ```
 Choose org.alfresco.maven.archetype:alfresco-allinone-archetype version:
@@ -134,6 +134,7 @@ Choose org.alfresco.maven.archetype:alfresco-allinone-archetype version:
 10: 3.0.1
 11: 4.0.0
 12: 4.1.0
+13: 4.2.0
 ```
 
 4. Next you will be prompted for additional values, like groupId, artifactId, and package, as shown below:
@@ -162,7 +163,7 @@ If everything has been configured correctly, you should see something similar to
 
 ```
 [INFO] ----------------------------------------------------------------------------
-[INFO] Using following parameters for creating project from Archetype: alfresco-allinone-archetype:4.1.0-SNAPSHOT
+[INFO] Using following parameters for creating project from Archetype: alfresco-allinone-archetype:4.2.0-SNAPSHOT
 [INFO] ----------------------------------------------------------------------------
 [INFO] Parameter: groupId, Value: com.acme
 [INFO] Parameter: artifactId, Value: my-all-in-one

--- a/docs/mvn-archetypes.md
+++ b/docs/mvn-archetypes.md
@@ -5,17 +5,17 @@ Last reviewed: 2019-10-18
 ---
 # Alfresco SDK Maven archetypes
 
-The Alfresco SDK 4.1 comes with a number of Maven archetypes that can be used to generate Alfresco extension projects.
+The Alfresco SDK 4.2 comes with a number of Maven archetypes that can be used to generate Alfresco extension projects.
 
-For more details, see [Getting started with Alfresco SDK 4.1](getting-started.md).
+For more details, see [Getting started with Alfresco SDK 4.2](getting-started.md).
 
 These archetypes are available during the creation of a brand new project. In short, a [Maven archetype](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html) 
 is a project templating toolkit. It's defined as an original pattern or model from which all other things of the same kind are made. Using archetypes 
 provides a great way to enable developers to quickly follow best practice in a consistent way. This is valid for every project built with Apache Maven and 
-it's valid in particular when using Alfresco SDK 4.1.
+it's valid in particular when using Alfresco SDK 4.2.
 
-In this section we are going to introduce all the available archetypes in Alfresco SDK 4.1, with a brief description of their purpose and main use. 
-After reading this information, you should be able to understand the various possibilities that Alfresco SDK 4.1 can offer to developers, in terms of 
+In this section we are going to introduce all the available archetypes in Alfresco SDK 4.2, with a brief description of their purpose and main use. 
+After reading this information, you should be able to understand the various possibilities that Alfresco SDK 4.2 can offer to developers, in terms of 
 projects.
 
 When generating your project, you'll be prompted to select the Maven archetype you want to use through an interactive menu, similar to what you can see below.
@@ -55,7 +55,7 @@ Please note that the numbering is not sequential and some numbers may be skipped
 ### org.alfresco.maven.archetype:alfresco-allinone-archetype
 
 This archetype allows a developer to implement the All-In-One project on Alfresco Content Services. The All-In-One project (also called AIO) is provided in 
-this and previous versions of Alfresco SDK, but in SDK 4.1 it has been reshaped to leverage on Docker.
+this and previous versions of Alfresco SDK, but in SDK 4.2 it has been reshaped to leverage on Docker.
 
 The All-In-One archetype allows a developer to create a multi-module project on Alfresco Content Services. The All-In-One project mainly includes a module for 
 the core repository in ACS and a module for the Share client. This includes:

--- a/docs/mvn-archetypes.md
+++ b/docs/mvn-archetypes.md
@@ -1,7 +1,7 @@
 ---
 Title: Alfresco SDK Maven archetypes
 Added: v2.1.1
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Alfresco SDK Maven archetypes
 

--- a/docs/mvn-archetypes.md
+++ b/docs/mvn-archetypes.md
@@ -55,7 +55,7 @@ Please note that the numbering is not sequential and some numbers may be skipped
 ### org.alfresco.maven.archetype:alfresco-allinone-archetype
 
 This archetype allows a developer to implement the All-In-One project on Alfresco Content Services. The All-In-One project (also called AIO) is provided in 
-this and previous versions of Alfresco SDK, but in SDK 4.2 it has been reshaped to leverage on Docker.
+this and previous versions of Alfresco SDK, but in SDK 4.1 it has been reshaped to leverage on Docker.
 
 The All-In-One archetype allows a developer to create a multi-module project on Alfresco Content Services. The All-In-One project mainly includes a module for 
 the core repository in ACS and a module for the Share client. This includes:

--- a/docs/setting-up-your-development-environment/dev-env-eclipse.md
+++ b/docs/setting-up-your-development-environment/dev-env-eclipse.md
@@ -9,7 +9,7 @@ The Maven Alfresco SDK is designed to work well with Eclipse. This support inclu
 Alfresco SDK.
 
 Here we assume you already have an Eclipse installation up and running, together with an available Alfresco project created using the Alfresco SDK. If you 
-don't have a project already, follow the steps in [Getting started with Alfresco SDK 4.1](../getting-started.md) to learn how to quickly generate it in a few 
+don't have a project already, follow the steps in [Getting started with Alfresco SDK 4.2](../getting-started.md) to learn how to quickly generate it in a few 
 easy steps.
 
 ## Importing the Alfresco project into Eclipse

--- a/docs/setting-up-your-development-environment/dev-env-eclipse.md
+++ b/docs/setting-up-your-development-environment/dev-env-eclipse.md
@@ -1,7 +1,7 @@
 ---
 Title: Setting up your development environment using Eclipse
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Setting up your development environment using Eclipse
 

--- a/docs/setting-up-your-development-environment/dev-env-intellij.md
+++ b/docs/setting-up-your-development-environment/dev-env-intellij.md
@@ -9,7 +9,7 @@ The Maven Alfresco SDK is designed to work well with Eclipse. This support inclu
 Alfresco SDK.
 
 Here we assume you already have an Eclipse installation up and running, together with an available Alfresco project created using the Alfresco SDK. If you 
-don't have a project already, follow the steps in [Getting started with Alfresco SDK 4.1](../getting-started.md) to learn how to quickly generate it in a few 
+don't have a project already, follow the steps in [Getting started with Alfresco SDK 4.2](../getting-started.md) to learn how to quickly generate it in a few 
 easy steps.
 
 ## Importing the Alfresco project into Intellij IDEA

--- a/docs/setting-up-your-development-environment/dev-env-intellij.md
+++ b/docs/setting-up-your-development-environment/dev-env-intellij.md
@@ -1,7 +1,7 @@
 ---
 Title: Setting up your development environment using Intellij IDEA
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Setting up your development environment using Intellij IDEA
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@ Last reviewed: 2019-10-18
 ---
 # Troubleshooting
 
-This article describes a list of common issues with the projects generated from the Alfresco SDK 4.1 archetypes and the way to troubleshoot them.
+This article describes a list of common issues with the projects generated from the Alfresco SDK 4.2 archetypes and the way to troubleshoot them.
 
 * [Incorrect JDK version](#incorrect-jdk-version)
 * [Containers synchronization](#containers-synchronization)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 Title: Troubleshooting
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Troubleshooting
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,14 +1,17 @@
 ---
 Title: What's new?
 Added: v2.1.1
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # What's new?
 
-Alfresco SDK 4.0 brings some changes oriented to assist the way the customizations are built, packaged, run and tested for Alfresco Content Services 6 and 
+Alfresco SDK 4.0 brought some changes oriented to assist the way the customizations are built, packaged, run and tested for Alfresco Content Services 6 and 
 Alfresco Share 6.
 
-This is a mayor release oriented to support Alfresco 6, so it is not compatible with previous versions of the SDK.
+This was a mayor release oriented to support Alfresco 6, so it is not compatible with previous versions of the SDK.
+
+Alfresco SDK 4.2 extends the support to Alfresco 7, while still being compatible with Alfresco 6 Enterprise. 
+Alfresco 6 Community is not officially supported in SDK 4.2, but is also likely to work. SDK 4.1 can be used for that, though. 
 
 ## Embracing containers and Docker
 
@@ -60,3 +63,7 @@ environment can be more similar to a real one, including whatever other service 
 ## Support for Alfresco 6.2.x
 
 Alfresco SDK 4.1 provides support for Alfresco 6.2.x.
+
+## Support for Alfresco 7.0.x
+
+Alfresco SDK 4.2 provides support for Alfresco 7.0.x.

--- a/docs/working-with-generated-projects/README.md
+++ b/docs/working-with-generated-projects/README.md
@@ -5,10 +5,10 @@ Last reviewed: 2019-10-18
 ---
 # Working with generated projects
 
-After generating a project using one of the Alfresco SDK 4.1 Maven archetypes, it is important to know how to build / run / test these projects.
+After generating a project using one of the Alfresco SDK 4.2 Maven archetypes, it is important to know how to build / run / test these projects.
 
 The Alfresco Platform 6 deployment architecture is highly based on container technologies, specifically in [Docker](http://docs.alfresco.com/6.0/concepts/master-deploy.html). 
-Due to that, the projects generated using the Alfresco SDK 4.1 archetypes set up their local environment making an intensive use of Docker and Docker compose 
+Due to that, the projects generated using the Alfresco SDK 4.2 archetypes set up their local environment making an intensive use of Docker and Docker compose 
 technologies.
 
 If you're not familiar with these technologies, it is highly recommended visiting the [Docker documentation website](https://docs.docker.com). This site offers
@@ -21,7 +21,7 @@ a great quantity of training resources about [Docker](https://docs.docker.com/ge
 ## Project structures
 
 After generating your project, using one of the Maven archetypes, review the project structure. The directory structure and content of each folder and file 
-can help you to understand how to start developing with the Alfresco SDK 4.1. Before continuing, make sure that you have read and completed the tasks in the 
+can help you to understand how to start developing with the Alfresco SDK 4.2. Before continuing, make sure that you have read and completed the tasks in the 
 [Getting started](../getting-started.md) tutorial.
 
 The structure of the project and the purpose of the files it contains vary according to the [Maven archetype](../mvn-archetypes.md) used to generate the project 
@@ -33,7 +33,7 @@ itself. The following links provide detailed descriptions of the different proje
 
 ## Run script
 
-All the projects generated using the Alfresco SDK 4.1 archetypes provide a utility script to work with the project. This script is `run.sh` for Unix systems
+All the projects generated using the Alfresco SDK 4.2 archetypes provide a utility script to work with the project. This script is `run.sh` for Unix systems
 and `run.bat` for Windows systems.
 
 The execution of this script must be followed by a parameter that dictates the task to be executed in the project. The list of available tasks is:

--- a/docs/working-with-generated-projects/README.md
+++ b/docs/working-with-generated-projects/README.md
@@ -1,7 +1,7 @@
 ---
 Title: Working with generated projects
 Added: v3.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 # Working with generated projects
 

--- a/docs/working-with-generated-projects/working-with-aio.md
+++ b/docs/working-with-generated-projects/working-with-aio.md
@@ -1,7 +1,7 @@
 ---
 Title: Working with an All-In-One project
 Added: v4.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 
 # Working with an All-In-One project
@@ -21,8 +21,8 @@ the AIO project was generated with the name `my-all-in-one-project`.
 -   [Stopping the project](#stopping-the-project)
 
 ## Introduction
-An AIO SDK project is used to build extensions for both [Alfresco Content Services (ACS) Repository](https://docs.alfresco.com/6.1/concepts/dev-platform-extensions.html) 
-and [Alfresco Share UI](https://docs.alfresco.com/6.1/concepts/dev-extensions-share.html). The runtime environment
+An AIO SDK project is used to build extensions for both [Alfresco Content Services (ACS) Repository](https://docs.alfresco.com/6.2/concepts/dev-platform-extensions.html) 
+and [Alfresco Share UI](https://docs.alfresco.com/6.2/concepts/dev-extensions-share.html). The runtime environment
 for ACS is Docker so not only is this project building the source code for your extensions but also the 
 custom Docker images for the Alfresco Repository and Alfresco Share. The custom Docker images includes the 
 JARs, or AMPs, with your extension code. 
@@ -47,8 +47,8 @@ The following table explains some of these properties:
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| alfresco.platform.version | `string` | 6.1.2-ga | The version of the ACS Repository (i.e. alfresco.war) that the Repository Extension should be applied to. This also specifies the version of the ACS Repository Docker Image that the custom built Repository image should be based on. See **my-all-in-one-project-platform-docker/src/main/docker/Dockerfile** |
-| alfresco.share.version | `string` | 6.1.0-RC3 | The version of Alfresco Share (i.e. share.war) that the Share Extension should be applied to. This also specifies the version of the Alfresco Share Docker Image that the custom built Share image should be based on. See **my-all-in-one-project-share-docker/src/main/docker/Dockerfile**|
+| alfresco.platform.version | `string` | 7.0.0-A20 | The version of the ACS Repository (i.e. alfresco.war) that the Repository Extension should be applied to. This also specifies the version of the ACS Repository Docker Image that the custom built Repository image should be based on. See **my-all-in-one-project-platform-docker/src/main/docker/Dockerfile** |
+| alfresco.share.version | `string` | 7.0.0-M3 | The version of Alfresco Share (i.e. share.war) that the Share Extension should be applied to. This also specifies the version of the Alfresco Share Docker Image that the custom built Share image should be based on. See **my-all-in-one-project-share-docker/src/main/docker/Dockerfile**|
 | docker.acs.image | `string` | alfresco/alfresco-content-repository-community | The name of the ACS Repository Docker image in Docker Hub. This changes if you switch to Enterprise Edition.|
 | docker.share.image | `string` | alfresco/alfresco-share | The name of the Alfresco Share Docker image in Docker Hub. This changes if you switch to Enterprise Edition.|
 | share.port | `number` | 8180 | The external port (i.e. outside container) for the Alfresco Share webapp.|
@@ -103,11 +103,11 @@ my-all-in-one-project-db-volume
 my-all-in-one-project-ass-volume
 ...
 Building my-all-in-one-project-share
-Step 1/8 : FROM alfresco/alfresco-share:6.1.0-RC3
+Step 1/8 : FROM alfresco/alfresco-share:7.0.0-M3
 ...
 Successfully tagged alfresco-share-my-all-in-one-project:development
 Building my-all-in-one-project-acs
-Step 1/9 : FROM alfresco/alfresco-content-repository-community:6.1.2-ga
+Step 1/9 : FROM alfresco/alfresco-content-repository-community:7.0.0-A20
 ...
 Successfully tagged alfresco-content-services-my-all-in-one-project:development
 ...

--- a/docs/working-with-generated-projects/working-with-aio.md
+++ b/docs/working-with-generated-projects/working-with-aio.md
@@ -78,7 +78,7 @@ my-all-in-one-project mbergljung$ ./run.sh build_start
 [INFO] ------------------------------------------------------------------------
 [INFO] Reactor Build Order:
 [INFO] 
-[INFO] AIO - SDK 4.1
+[INFO] AIO - SDK 4.2
 [INFO] Alfresco Platform/Repository JAR Module
 [INFO] Alfresco Share JAR Module
 [INFO] Integration Tests Module
@@ -88,7 +88,7 @@ my-all-in-one-project mbergljung$ ./run.sh build_start
 [INFO] ------------------------------------------------------------------------
 [INFO] Reactor Summary:
 [INFO] 
-[INFO] AIO - SDK 4.1 ...................................... SUCCESS [  0.680 s]
+[INFO] AIO - SDK 4.2 ...................................... SUCCESS [  0.680 s]
 [INFO] Alfresco Platform/Repository JAR Module ............ SUCCESS [  5.461 s]
 [INFO] Alfresco Share JAR Module .......................... SUCCESS [  0.557 s]
 [INFO] Integration Tests Module ........................... SUCCESS [  0.900 s]

--- a/docs/working-with-generated-projects/working-with-platform.md
+++ b/docs/working-with-generated-projects/working-with-platform.md
@@ -1,7 +1,7 @@
 ---
 Title: Working with a Platform (Repository) project
 Added: v4.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 
 # Working with a Platform (Repository) project
@@ -21,7 +21,7 @@ the Platform project was generated with the name `my-platform-project`.
 -   [Stopping the project](#stopping-the-project)
 
 ## Introduction
-A Platform project is used to build extensions for the [Alfresco Content Services (ACS) Repository](https://docs.alfresco.com/6.1/concepts/dev-platform-extensions.html). 
+A Platform project is used to build extensions for the [Alfresco Content Services (ACS) Repository](https://docs.alfresco.com/6.2/concepts/dev-platform-extensions.html). 
 The runtime environment for ACS is Docker so not only is this project building the source code for your extensions but also the 
 custom Docker image for the Alfresco Repository. The custom Docker images includes the JARs, or AMPs, with your extension code. 
 
@@ -38,8 +38,8 @@ The following table explains some of these properties:
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| alfresco.platform.version | `string` | 6.1.2-ga | The version of the ACS Repository (i.e. alfresco.war) that the Repository Extension should be applied to. This also specifies the version of the ACS Repository Docker Image that the custom built Repository image should be based on. See **my-platform-project-platform-docker/src/main/docker/Dockerfile** |
-| alfresco.share.version | `string` | 6.1.0-RC3 | The version of Alfresco Share (i.e. share.war) that the Share Extension should be applied to. This also specifies the version of the Alfresco Share Docker Image that the custom built Share image should be based on. See **my-platform-project-share-docker/src/main/docker/Dockerfile**|
+| alfresco.platform.version | `string` | 7.0.0-A20 | The version of the ACS Repository (i.e. alfresco.war) that the Repository Extension should be applied to. This also specifies the version of the ACS Repository Docker Image that the custom built Repository image should be based on. See **my-platform-project-platform-docker/src/main/docker/Dockerfile** |
+| alfresco.share.version | `string` | 7.0.0-M3 | The version of Alfresco Share (i.e. share.war) that the Share Extension should be applied to. This also specifies the version of the Alfresco Share Docker Image that the custom built Share image should be based on. See **my-platform-project-share-docker/src/main/docker/Dockerfile**|
 | docker.acs.image | `string` | alfresco/alfresco-content-repository-community | The name of the ACS Repository Docker image in Docker Hub. This changes if you switch to Enterprise Edition.|
 | docker.share.image | `string` | alfresco/alfresco-share | The name of the Alfresco Share Docker image in Docker Hub. This changes if you switch to Enterprise Edition.|
 | share.port | `number` | 8180 | The external port (i.e. outside container) for the Alfresco Share webapp.|

--- a/docs/working-with-generated-projects/working-with-share.md
+++ b/docs/working-with-generated-projects/working-with-share.md
@@ -1,7 +1,7 @@
 ---
 Title: Working with a Share project
 Added: v4.0.0
-Last reviewed: 2019-10-18
+Last reviewed: 2021-02-09
 ---
 
 # Working with a Share project
@@ -21,7 +21,7 @@ the Share project was generated with the name `my-share-project`.
 -   [Stopping the project](#stopping-the-project)
 
 ## Introduction
-An Alfresco Sharte project is used to build extensions for [Alfresco Share UI](https://docs.alfresco.com/6.1/concepts/dev-extensions-share.html). 
+An Alfresco Sharte project is used to build extensions for [Alfresco Share UI](https://docs.alfresco.com/6.2/concepts/dev-extensions-share.html). 
 The runtime environment for ACS is Docker so not only is this project building the source code for your extensions but also the 
 custom Docker image for Alfresco Share. The custom Docker images includes the 
 JARs, or AMPs, with your extension code. 
@@ -39,8 +39,8 @@ The following table explains some of these properties:
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| alfresco.platform.version | `string` | 6.1.2-ga | The version of the ACS Repository (i.e. alfresco.war) that the Repository Extension should be applied to. This also specifies the version of the ACS Repository Docker Image that the custom built Repository image should be based on. See **my-share-project-platform-docker/src/main/docker/Dockerfile** |
-| alfresco.share.version | `string` | 6.1.0-RC3 | The version of Alfresco Share (i.e. share.war) that the Share Extension should be applied to. This also specifies the version of the Alfresco Share Docker Image that the custom built Share image should be based on. See **my-share-project-share-docker/src/main/docker/Dockerfile**|
+| alfresco.platform.version | `string` | 7.0.0-A20 | The version of the ACS Repository (i.e. alfresco.war) that the Repository Extension should be applied to. This also specifies the version of the ACS Repository Docker Image that the custom built Repository image should be based on. See **my-share-project-platform-docker/src/main/docker/Dockerfile** |
+| alfresco.share.version | `string` | 7.0.0-M3 | The version of Alfresco Share (i.e. share.war) that the Share Extension should be applied to. This also specifies the version of the Alfresco Share Docker Image that the custom built Share image should be based on. See **my-share-project-share-docker/src/main/docker/Dockerfile**|
 | docker.acs.image | `string` | alfresco/alfresco-content-repository-community | The name of the ACS Repository Docker image in Docker Hub. This changes if you switch to Enterprise Edition.|
 | docker.share.image | `string` | alfresco/alfresco-share | The name of the Alfresco Share Docker image in Docker Hub. This changes if you switch to Enterprise Edition.|
 | share.port | `number` | 8180 | The external port (i.e. outside container) for the Alfresco Share webapp.|

--- a/modules/alfresco-rad/pom.xml
+++ b/modules/alfresco-rad/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugins/alfresco-maven-plugin/pom.xml
+++ b/plugins/alfresco-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-aggregator</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,9 +210,13 @@
             <id>central-releases-staging</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
+<!--        <snapshotRepository>-->
+<!--            <id>central-snapshots</id>-->
+<!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+<!--        </snapshotRepository>-->
         <snapshotRepository>
-            <id>central-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>alfresco-public-snapshots</id>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots</url>
         </snapshotRepository>
         <site>
             <id>alfresco-docs</id>
@@ -294,7 +298,7 @@
             <id>community-62-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>6.2.2-RC1</alfresco.platform.version>
+                <alfresco.platform.version>6.2.0-ea</alfresco.platform.version>
                 <alfresco.share.version>6.2.2</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>

--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,8 @@
         <alfresco.sdk.tests.exclude>*/*-enterprise*/*</alfresco.sdk.tests.exclude>
 
         <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-        <alfresco.platform.version>6.2.0-ea</alfresco.platform.version>
-        <alfresco.share.version>6.2.0</alfresco.share.version>
+        <alfresco.platform.version>7.0.0-A20</alfresco.platform.version>
+        <alfresco.share.version>7.0.0-M3</alfresco.share.version>
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
 
@@ -373,6 +373,30 @@
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.2.0</alfresco.platform.version>
                 <alfresco.share.version>6.2.0</alfresco.share.version>
+                <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+            </properties>
+        </profile>
+
+        <!-- 7.0 -->
+        <!-- This profiles requires to be executed using Java 11 -->
+        <profile>
+            <id>community-70-tests</id>
+            <properties>
+                <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
+                <alfresco.platform.version>7.0.0-A20</alfresco.platform.version>
+                <alfresco.share.version>7.0.0-M3</alfresco.share.version>
+                <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>enterprise-70-tests</id>
+            <properties>
+                <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
+                <alfresco.platform.version>7.0.0-A20</alfresco.platform.version>
+                <alfresco.share.version>7.0.0-M3</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco.maven</groupId>
     <artifactId>alfresco-sdk-aggregator</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <name>Alfresco SDK</name>
     <description>This aggregator Project builds all modules required for the Alfresco SDK</description>
     <packaging>pom</packaging>
@@ -30,7 +30,7 @@
         <connection>scm:git:${scm.url.base}.git</connection>
         <developerConnection>scm:git:${scm.url.base}</developerConnection>
         <url>${scm.url.base}</url>
-        <tag>alfresco-sdk-aggregator-4.1.0-SNAPSHOT</tag>
+        <tag>alfresco-sdk-aggregator-4.2.0-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
     <licenses>
         <license>
-            <name>GNU Lesser General Public License v3.0 or later</name>
-            <url>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</url>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
 
@@ -33,85 +33,6 @@
         <tag>alfresco-sdk-aggregator-4.2.0-SNAPSHOT</tag>
     </scm>
 
-    <developers>
-
-        <developer>
-            <id>ohej</id>
-            <name>Ole Hejlskov</name>
-            <email>ole@phpfreak.dk</email>
-            <url>http://ohej.dk/</url>
-            <organization>Alfresco</organization>
-            <organizationUrl>http://www.alfresco.com</organizationUrl>
-            <timezone>+1</timezone>
-            <roles>
-                <role>Developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <id>gravitonian</id>
-            <name>Martin Bergljung</name>
-            <email>martin.bergljung@alfresco.com</email>
-            <url>https://sites.google.com/site/gravitonian/</url>
-            <organization>Alfresco Software</organization>
-            <organizationUrl>http://www.alfresco.com</organizationUrl>
-            <timezone>+0</timezone>
-            <roles>
-                <role>Architect</role>
-                <role>Developer</role>
-            </roles>
-        </developer>
-    </developers>
-
-    <contributors>
-        <contributor>
-            <name>Gabriele Columbro</name>
-            <email>gabriele.columbro@alfresco.com</email>
-            <url>http://mindthegab.com</url>
-            <organization>Alfresco Software</organization>
-            <organizationUrl>http://www.alfresco.com</organizationUrl>
-            <timezone>-5</timezone>
-        </contributor>
-        <contributor>
-            <name>Maurizio Pillitu</name>
-            <email>maurizio.pillitu@alfresco.com</email>
-            <url>http://session.it</url>
-            <organization>Alfresco Software</organization>
-            <organizationUrl>http://www.alfresco.com</organizationUrl>
-            <timezone>+1</timezone>
-        </contributor>
-        <contributor>
-            <name>Carlo Sciolla</name>
-            <email>carlo@backbase.com</email>
-            <organization>Backbase</organization>
-            <organizationUrl>http://www.backbase.com</organizationUrl>
-            <timezone>+1</timezone>
-            <url>http://skuro.tk</url>
-        </contributor>
-        <contributor>
-            <name>Samuel Langlois</name>
-            <email>samuel.langlois@alfresco.com</email>
-            <organization>Alfresco Software</organization>
-            <organizationUrl>http://www.alfresco.com</organizationUrl>
-            <timezone>+0</timezone>
-            <url>https://twitter.com/samuel_langlois</url>
-        </contributor>
-        <contributor>
-            <name>Ray Gauss II</name>
-            <email>ray.gauss@alfresco.com</email>
-            <organization>Alfresco Software</organization>
-            <organizationUrl>http://www.alfresco.com</organizationUrl>
-            <timezone>-5</timezone>
-            <url>http://rgauss.com/</url>
-        </contributor>
-        <contributor>
-            <name>Jose Luis Osorno Gil</name>
-            <email>joseluis.osorno@ixxus.com</email>
-            <organization>Ixxus</organization>
-            <organizationUrl>http://www.ixxus.com</organizationUrl>
-            <timezone>+1</timezone>
-        </contributor>
-    </contributors>
-
     <!-- All the modules of the Alfresco SDK -->
     <modules>
         <!-- Modules -->
@@ -123,7 +44,6 @@
         <module>archetypes/alfresco-share-jar-archetype</module>
         <module>archetypes/alfresco-allinone-archetype</module>
         <module>archetypes/archetypes-it</module>
-
   </modules>
 
     <properties>
@@ -139,8 +59,17 @@
         <alfresco.share.version>7.0.0-M3</alfresco.share.version>
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
-
-        <test.acs.endpoint.path />
+        <keystore.settings>
+            -Dencryption.keystore.type=JCEKS
+            -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
+            -Dencryption.keyAlgorithm=AES
+            -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
+            -Dmetadata-keystore.password=mp6yc0UD9e
+            -Dmetadata-keystore.aliases=metadata
+            -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+            -Dmetadata-keystore.metadata.algorithm=AES
+        </keystore.settings>
+        <test.acs.endpoint.path/>
 
         <scm.url.base>https://github.com/Alfresco/alfresco-sdk</scm.url.base>
     </properties>
@@ -316,6 +245,7 @@
                 <alfresco.share.version>6.0.b</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <keystore.settings></keystore.settings>
             </properties>
         </profile>
 
@@ -327,6 +257,7 @@
                 <alfresco.share.version>6.0</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <keystore.settings></keystore.settings>
             </properties>
         </profile>
 
@@ -340,6 +271,7 @@
                 <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <keystore.settings></keystore.settings>
             </properties>
         </profile>
 
@@ -351,6 +283,7 @@
                 <alfresco.share.version>6.1.0</alfresco.share.version>
                 <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
+                <keystore.settings></keystore.settings>
             </properties>
         </profile>
 
@@ -364,6 +297,7 @@
                 <alfresco.share.version>6.2.0</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <keystore.settings></keystore.settings>
             </properties>
         </profile>
 
@@ -375,6 +309,7 @@
                 <alfresco.share.version>6.2.0</alfresco.share.version>
                 <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
+                <keystore.settings></keystore.settings>
             </properties>
         </profile>
 
@@ -516,5 +451,84 @@
         </profile>
          -->
     </profiles>
+
+    <developers>
+
+        <developer>
+            <id>ohej</id>
+            <name>Ole Hejlskov</name>
+            <email>ole@phpfreak.dk</email>
+            <url>http://ohej.dk/</url>
+            <organization>Alfresco</organization>
+            <organizationUrl>http://www.alfresco.com</organizationUrl>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>gravitonian</id>
+            <name>Martin Bergljung</name>
+            <email>martin.bergljung@alfresco.com</email>
+            <url>https://sites.google.com/site/gravitonian/</url>
+            <organization>Alfresco Software</organization>
+            <organizationUrl>http://www.alfresco.com</organizationUrl>
+            <timezone>+0</timezone>
+            <roles>
+                <role>Architect</role>
+                <role>Developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <contributors>
+        <contributor>
+            <name>Gabriele Columbro</name>
+            <email>gabriele.columbro@alfresco.com</email>
+            <url>http://mindthegab.com</url>
+            <organization>Alfresco Software</organization>
+            <organizationUrl>http://www.alfresco.com</organizationUrl>
+            <timezone>-5</timezone>
+        </contributor>
+        <contributor>
+            <name>Maurizio Pillitu</name>
+            <email>maurizio.pillitu@alfresco.com</email>
+            <url>http://session.it</url>
+            <organization>Alfresco Software</organization>
+            <organizationUrl>http://www.alfresco.com</organizationUrl>
+            <timezone>+1</timezone>
+        </contributor>
+        <contributor>
+            <name>Carlo Sciolla</name>
+            <email>carlo@backbase.com</email>
+            <organization>Backbase</organization>
+            <organizationUrl>http://www.backbase.com</organizationUrl>
+            <timezone>+1</timezone>
+            <url>http://skuro.tk</url>
+        </contributor>
+        <contributor>
+            <name>Samuel Langlois</name>
+            <email>samuel.langlois@alfresco.com</email>
+            <organization>Alfresco Software</organization>
+            <organizationUrl>http://www.alfresco.com</organizationUrl>
+            <timezone>+0</timezone>
+            <url>https://twitter.com/samuel_langlois</url>
+        </contributor>
+        <contributor>
+            <name>Ray Gauss II</name>
+            <email>ray.gauss@alfresco.com</email>
+            <organization>Alfresco Software</organization>
+            <organizationUrl>http://www.alfresco.com</organizationUrl>
+            <timezone>-5</timezone>
+            <url>http://rgauss.com/</url>
+        </contributor>
+        <contributor>
+            <name>Jose Luis Osorno Gil</name>
+            <email>joseluis.osorno@ixxus.com</email>
+            <organization>Ixxus</organization>
+            <organizationUrl>http://www.ixxus.com</organizationUrl>
+            <timezone>+1</timezone>
+        </contributor>
+    </contributors>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.archetype.version>3.0.0</maven.archetype.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,10 +210,6 @@
             <id>central-releases-staging</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
-<!--        <snapshotRepository>-->
-<!--            <id>central-snapshots</id>-->
-<!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
-<!--        </snapshotRepository>-->
         <snapshotRepository>
             <id>alfresco-public-snapshots</id>
             <url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots</url>

--- a/pom.xml
+++ b/pom.xml
@@ -349,8 +349,8 @@
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.1.0</alfresco.platform.version>
                 <alfresco.share.version>6.1.0</alfresco.share.version>
-                <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
-                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
             </properties>
         </profile>
 
@@ -373,8 +373,8 @@
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.2.0</alfresco.platform.version>
                 <alfresco.share.version>6.2.0</alfresco.share.version>
-                <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
-                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
             </properties>
         </profile>
 
@@ -397,8 +397,8 @@
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>7.0.0-A20</alfresco.platform.version>
                 <alfresco.share.version>7.0.0-M3</alfresco.share.version>
-                <alfresco.platform.docker.image>alfresco/alfresco-content-repository</alfresco.platform.docker.image>
-                <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
+                <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
+                <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
             <properties>
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
                 <alfresco.platform.version>6.1.2-ga</alfresco.platform.version>
-                <alfresco.share.version>6.1.0-RC3</alfresco.share.version>
+                <alfresco.share.version>6.1.1</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
                 <keystore.settings></keystore.settings>
@@ -294,8 +294,8 @@
             <id>community-62-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>6.2.0-ea</alfresco.platform.version>
-                <alfresco.share.version>6.2.0</alfresco.share.version>
+                <alfresco.platform.version>6.2.2-RC1</alfresco.platform.version>
+                <alfresco.share.version>6.2.2</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
                 <keystore.settings></keystore.settings>
@@ -306,8 +306,8 @@
             <id>enterprise-62-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>6.2.0</alfresco.platform.version>
-                <alfresco.share.version>6.2.0</alfresco.share.version>
+                <alfresco.platform.version>6.2.2.10</alfresco.platform.version>
+                <alfresco.share.version>6.2.2.2</alfresco.share.version>
                 <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
                 <keystore.settings></keystore.settings>
@@ -331,7 +331,7 @@
             <id>enterprise-70-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>7.0.0-A20</alfresco.platform.version>
+                <alfresco.platform.version>repo-5439-M3v2</alfresco.platform.version>
                 <alfresco.share.version>7.0.0-M3</alfresco.share.version>
                 <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>


### PR DESCRIPTION
SDK 4.2

Migrated from Bamboo to Travis
Adapted to work with ACS 7
Dynamically handling the Keystore settings as needed (7+ yes, 6.x no)
Updated docs 
Fixed License inconsistencies