### PR TITLE
Fix alfresco platform jar archetype docker-compose which was using wrong property for share docker image version.

### DIFF
--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 services:
 #  Optional
 #  ${rootArtifactId}-share:
-#    image: ${symbol_dollar}{docker.share.image}:${symbol_dollar}{alfresco.share.version}
+#    image: ${symbol_dollar}{docker.share.image}:${symbol_dollar}{alfresco.share.docker.version}
 #    environment:
 #      REPO_HOST: ${rootArtifactId}-acs
 #      REPO_PORT: 8080


### PR DESCRIPTION
Platform archetype has an optional config for share docker image. It was using the wrong property and hence image was getting failed to download. 
Updated the image config to use "alfresco.share.docker.version" instead of "alfresco.share.version".