### PR TITLE
Moved the activemq-all dependency from parent pom.xml to platform-docker pom.xml.

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/__rootArtifactId__-platform-docker/pom.xml
@@ -41,6 +41,12 @@
                 </exclusions>
              to each amp dependency definition.
          -->
+         
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-all</artifactId>
+            <version>${activemq.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/pom.xml
@@ -85,13 +85,6 @@
             <version>${alfresco.sdk.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-all</artifactId>
-            <version>${activemq.version}</version>
-        </dependency>
-
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
Moved the activemq-all dependency from parent pom.xml to platform-docker pom.xml in order to avoid it being included in the amp. Inclusion in the amp caused issues when amp is deployed on a server.

See the issue description here as well: https://hub.alfresco.com/t5/alfresco-content-services-forum/error-deploying-aio-with-sdk-4-3/m-p/310967/highlight/false#M26453

I have replicated the issue and tested on this demo project : https://github.com/abhinavmishra14/acs7-sdk43-demo

platform docker project: https://github.com/abhinavmishra14/acs7-sdk43-demo/blob/main/acs71-demo-platform-docker/pom.xml#L33

parent pom: https://github.com/abhinavmishra14/acs7-sdk43-demo/blob/main/acs71-demo-platform-docker/pom.xml#L33
