### PR TITLE
MNT-22384: Inline keystore settings to avoid invalid docker-compose file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,7 @@
         <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
         <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
         <keystore.settings>
-            -Dencryption.keystore.type=JCEKS
-            -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
-            -Dencryption.keyAlgorithm=AES
-            -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
-            -Dmetadata-keystore.password=mp6yc0UD9e
-            -Dmetadata-keystore.aliases=metadata
-            -Dmetadata-keystore.metadata.password=oKIWzVdEdA
-            -Dmetadata-keystore.metadata.algorithm=AES
+            -Dencryption.keystore.type=JCEKS -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding -Dencryption.keyAlgorithm=AES -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore -Dmetadata-keystore.password=mp6yc0UD9e -Dmetadata-keystore.aliases=metadata -Dmetadata-keystore.metadata.password=oKIWzVdEdA -Dmetadata-keystore.metadata.algorithm=AES
         </keystore.settings>
 
         <test.acs.endpoint.path/>


### PR DESCRIPTION
The purpose of this PR is to fix an error that occurs when we try to build a project using the alfresco-share-jar-archetype. Inlining the keystore settings prevents those lines from not being commented out and thus not resulting in an invalid docker-compose file 
[https://alfresco.atlassian.net/browse/MNT-22384](https://alfresco.atlassian.net/browse/MNT-22384)

[Edit] The problem initially occurs because of this commented out line in the docker-compose template for the share jar archetype `# ${symbol_dollar}{keystore.settings}` which then gets replaced by the value of keystore settings in the `pom.xml` file. What ends up happening is only the first of those settings is put in a comment and so that results in an invalid yaml file