### PR TITLE
[APPS-3205] Update community version from 23.4.0 & 23.3.0 to 23.4.1 & 23.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
         <alfresco.sdk.tests.exclude>*/*-enterprise*/*</alfresco.sdk.tests.exclude>
 
         <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-        <alfresco.platform.version>23.4.0</alfresco.platform.version>
+        <alfresco.platform.version>23.4.1</alfresco.platform.version>
         <alfresco.platform.docker.user>alfresco</alfresco.platform.docker.user>
-        <alfresco.share.docker.version>23.4.0</alfresco.share.docker.version>
+        <alfresco.share.docker.version>23.4.1</alfresco.share.docker.version>
         <!--
              The following value is now obtained by looking at the
              - alfresco-community-share.version (eg. https://github.com/Alfresco/acs-community-packaging/blob/23.4.0/pom.xml#L17)
@@ -255,8 +255,8 @@
             <id>community-233-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>23.3.0</alfresco.platform.version>
-                <alfresco.share.docker.version>23.3.0</alfresco.share.docker.version>
+                <alfresco.platform.version>23.3.3</alfresco.platform.version>
+                <alfresco.share.docker.version>23.3.3</alfresco.share.docker.version>
                 <alfresco.share.version>23.3.0.85</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
@@ -267,8 +267,8 @@
             <id>enterprise-233-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>23.3.0</alfresco.platform.version>
-                <alfresco.share.docker.version>23.3.0</alfresco.share.docker.version>
+                <alfresco.platform.version>23.3.3</alfresco.platform.version>
+                <alfresco.share.docker.version>23.3.3</alfresco.share.docker.version>
                 <alfresco.share.version>23.3.0.85</alfresco.share.version>
                 <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>
@@ -281,8 +281,8 @@
             <id>community-234-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-community-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>23.4.0</alfresco.platform.version>
-                <alfresco.share.docker.version>23.4.0</alfresco.share.docker.version>
+                <alfresco.platform.version>23.4.1</alfresco.platform.version>
+                <alfresco.share.docker.version>23.4.1</alfresco.share.docker.version>
                 <alfresco.share.version>23.4.0.46</alfresco.share.version>
                 <alfresco.platform.docker.image>alfresco/alfresco-content-repository-community</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>alfresco/alfresco-share</alfresco.share.docker.image>
@@ -293,8 +293,8 @@
             <id>enterprise-234-tests</id>
             <properties>
                 <alfresco.bomDependency.artifactId>acs-packaging</alfresco.bomDependency.artifactId>
-                <alfresco.platform.version>23.4.0</alfresco.platform.version>
-                <alfresco.share.docker.version>23.4.0</alfresco.share.docker.version>
+                <alfresco.platform.version>23.4.1</alfresco.platform.version>
+                <alfresco.share.docker.version>23.4.1</alfresco.share.docker.version>
                 <alfresco.share.version>23.4.0.46</alfresco.share.version>
                 <alfresco.platform.docker.image>quay.io/alfresco/alfresco-content-repository</alfresco.platform.docker.image>
                 <alfresco.share.docker.image>quay.io/alfresco/alfresco-share</alfresco.share.docker.image>


### PR DESCRIPTION
https://hyland.atlassian.net/browse/APPS-3205

Due to Quiklink issue the older versions of community repo(**23.4.0 & 23.3.0**) is removed. Following new version is released
**(23.4.1 & 23.3.3)**. So this needs to updated here.