### PR TITLE
[MNT-25067]: AIO and Alfresco platform docker compose file update with new version

### DIFF
--- a/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-allinone-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - ${rootArtifactId}-postgres
   ${rootArtifactId}-postgres:
-    image: postgres:9.6
+    image: postgres:16.5
     environment:
       POSTGRES_DB: alfresco
       POSTGRES_USER: alfresco
@@ -45,7 +45,7 @@ services:
     volumes:
       - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
   ${rootArtifactId}-ass:
-    image: alfresco/alfresco-search-services:2.0.3
+    image: alfresco/alfresco-search-services:2.0.15
     environment:
       SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
       SOLR_ALFRESCO_PORT: 8080
@@ -60,7 +60,7 @@ services:
       - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/contentstore
       - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/data
   ${rootArtifactId}-activemq:
-      image: alfresco/alfresco-activemq:5.16.1
+      image: alfresco/alfresco-activemq:5.18-jre17-rockylinux8
       mem_limit: 1g
       ports:
         - 8161:8161 # Web Console

--- a/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
+++ b/archetypes/alfresco-platform-jar-archetype/src/main/resources/archetype-resources/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     depends_on:
       - ${rootArtifactId}-postgres
   ${rootArtifactId}-postgres:
-    image: postgres:9.6
+    image: postgres:16.5
     environment:
       POSTGRES_DB: alfresco
       POSTGRES_USER: alfresco
@@ -41,7 +41,7 @@ services:
     volumes:
       - ${rootArtifactId}-db-volume:/var/lib/postgresql/data
   ${rootArtifactId}-ass:
-    image: alfresco/alfresco-search-services:2.0.3
+    image: alfresco/alfresco-search-services:2.0.15
     environment:
       SOLR_ALFRESCO_HOST: ${rootArtifactId}-acs
       SOLR_ALFRESCO_PORT: 8080
@@ -56,7 +56,7 @@ services:
       - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/contentstore
       - ${rootArtifactId}-ass-volume:/opt/alfresco-search-services/data
   ${rootArtifactId}-activemq:
-      image: alfresco/alfresco-activemq:5.16.1
+      image: alfresco/alfresco-activemq:5.18-jre17-rockylinux8
       mem_limit: 1g
       ports:
         - 8161:8161 # Web Console


### PR DESCRIPTION
The root cause of the issue is that when generating a project using Alfresco SDK 4.11.0, Maven downloads the project archetype (such as the AIO module) from Nexus. This archetype is packaged as a JAR file and contains a predefined docker-compose.yml file. Unfortunately, this file includes outdated Docker image versions that are no longer recommended for ACS 25.1.

To resolve this,

1. Updated the docker-compose.yml file in the SDK source repository to include the latest supported Docker image versions (as per the Supported Platforms documentation).

2. Raised a pull request (PR) with these updates.

Once this PR is merged, a new SDK version will be released. This new version will include the updated archetype JAR.