### PR TITLE
[ACS-11984]: Review security and quality findings on Alfresco SDK

### DIFF
--- a/plugins/alfresco-maven-plugin/pom.xml
+++ b/plugins/alfresco-maven-plugin/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.6</version>
             <exclusions>
                 <exclusion>
                     <artifactId>maven-core</artifactId>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -450,9 +450,10 @@
     </profiles>
 
     <!--
-        Force transitive dependencies to safe versions (CVE fixes).
-        Any version declared here overrides versions brought in transitively
-        by other dependencies in this project and all child modules.
+        Date: 12-06-2026
+        Force transitive dependencies to safe versions.
+        Remove this when bumping the "alfresco-repository" 26.2 GA in the future,
+        as the fixed version of plexus-utils will be included in the dependency tree of the project.
     -->
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,21 @@
         </profile>
     </profiles>
 
+    <!--
+        Force transitive dependencies to safe versions (CVE fixes).
+        Any version declared here overrides versions brought in transitively
+        by other dependencies in this project and all child modules.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
We are fixing: https://github.com/Alfresco/alfresco-sdk/security/dependabot/13

The reason of adding org.codehaus.plexus:plexus-utils under dependency management is that:

Currently it is getting fetched from several places. One of them is alfresco-reposiotry 26.1.
Although alfresco-repository 26.2 will have the bumped version, but its GA is not released yet.
So, we cannot use 26.2 GA now.

And also bumped other maven dependencies which transitively fetches "plexus"

Earlier:
<img width="655" height="339" alt="image" src="https://github.com/user-attachments/assets/d84e4abf-4b57-4ad2-9ba0-8c95331a210a" />

Now:
<img width="712" height="394" alt="image" src="https://github.com/user-attachments/assets/231a937a-7d71-4d5a-8c95-59d87bef16e0" />


