### PR TITLE
ACS-12085 Migrate SDK Repositories  Verified Commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
       - feature/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
@@ -138,16 +141,66 @@ jobs:
       - name: "Build"
         run: mvn clean install -B ${{ matrix.suite }}
 
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [tests]
+    outputs:
+      release_tag: ${{ steps.versions.outputs['release-version'] }}
+    env:
+      MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+    if: >
+      !(failure() || cancelled()) &&
+      (github.ref_name == 'master' || startsWith(github.ref_name, 'fix/') || startsWith(github.ref_name, 'feature/')) &&
+      !contains(github.event.head_commit.message, '[no release]') &&
+      github.event_name != 'pull_request' &&
+      contains(github.event.head_commit.message, '[release]')
+    steps:
+      - name: "Generate GitHub App token"
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+          permission-contents: write
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v18.21.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v18.21.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v18.21.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-compute-release-versions@v18.21.0
+        id: versions
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.21.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release-version: ${{ steps.versions.outputs['release-version'] }}
+          development-version: ${{ steps.versions.outputs['next-development-version'] }}
+          maven-args: >
+            -DskipTests
+            -DbuildNumber=${{ github.run_number }}
+
   check_version:
     name: "Check version"
     runs-on: ubuntu-latest
-    needs: [tests]
+    needs: [tests, release]
     if: >
-      contains(github.event.head_commit.message, '[publish]')
+      contains(github.event.head_commit.message, '[publish]') &&
+      !cancelled() &&
+      (needs.release.result == 'success' || needs.release.result == 'skipped')
     outputs:
         is_ga: ${{ steps.publish_version.outputs.is_ga }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.release.outputs.release_tag || github.ref }}
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
         with:
@@ -167,13 +220,18 @@ jobs:
   publish:
     name: "Publish artifacts"
     runs-on: ubuntu-latest
-    needs: [tests, check_version]
+    needs: [tests, check_version, release]
     if: >
-      contains(github.event.head_commit.message, '[publish]') && needs.check_version.outputs.is_ga == 'true'
+      contains(github.event.head_commit.message, '[publish]') &&
+      needs.check_version.outputs.is_ga == 'true' &&
+      !cancelled() &&
+      (needs.release.result == 'success' || needs.release.result == 'skipped')
     env:
       GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.release.outputs.release_tag || github.ref }}
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ env:
   MAVEN_CENTRAL_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
   MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 90
+  # Both variables are required to be set before the release process starts.
+  # As the release is triggered by a commit message with "[release]" keyword,
+  # setting these variables to new values can be done in the same commit and will indicate the release and the dev versions in it.
+  RELEASE_VERSION: "4.17.0-A2" # The version of the release (tag).
+  DEVELOPMENT_VERSION: "4.17.0-A3" # The version that will be set in pom files after the release (next dev version).
 
 jobs:
   pre_commit:
@@ -148,7 +153,7 @@ jobs:
       contents: write
     needs: [tests]
     outputs:
-      release_tag: ${{ steps.versions.outputs['release-version'] }}
+      release_tag: ${{ env.RELEASE_VERSION }}
     env:
       MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
@@ -166,23 +171,21 @@ jobs:
           client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
           permission-contents: write
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
           fetch-depth: 0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v18.21.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v18.21.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v18.21.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v18.21.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v18.21.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v18.21.2
         with:
           java-version: ${{ env.JAVA_VERSION }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-compute-release-versions@v18.21.0
-        id: versions
-      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.21.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.21.2
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-version: ${{ steps.versions.outputs['release-version'] }}
-          development-version: ${{ steps.versions.outputs['next-development-version'] }}
+          release-version: ${{ env.RELEASE_VERSION }}
+          development-version: ${{ env.DEVELOPMENT_VERSION }}
           maven-args: >
             -DskipTests
             -DbuildNumber=${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     if: >
-      !(failure() || cancelled()) &&
+      needs.tests.result == 'success' &&
       (github.ref_name == 'master' || startsWith(github.ref_name, 'fix/') || startsWith(github.ref_name, 'feature/')) &&
       !contains(github.event.head_commit.message, '[no release]') &&
       github.event_name != 'pull_request' &&
@@ -192,8 +192,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, release]
     if: >
+      needs.tests.result == 'success' &&
       contains(github.event.head_commit.message, '[publish]') &&
-      !cancelled() &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     outputs:
         is_ga: ${{ steps.publish_version.outputs.is_ga }}
@@ -222,9 +222,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, check_version, release]
     if: >
+      needs.tests.result == 'success' &&
       contains(github.event.head_commit.message, '[publish]') &&
+      needs.check_version.result == 'success' &&
       needs.check_version.outputs.is_ga == 'true' &&
-      !cancelled() &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     env:
       GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to introduce a controlled release process and improve artifact publishing. The main changes add a new `release` job, adjust dependencies between jobs, and ensure that publishing and version checks only happen after a successful (or intentionally skipped) release.

**Release process improvements:**

* Added a new `release` job to the workflow, which handles generating a release using a GitHub App token, computes release versions, and updates Maven project versions. This job only runs on specific branches and when the commit message includes `[release]`.
* Configured the workflow to require the `release` job to succeed (or be skipped) before running the `check_version` and `publish` jobs, ensuring that publishing only happens after a valid release. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR144-R203) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL170-R234)

**Security and permissions:**

* Set explicit `permissions` for the workflow and for the `release` job to control access to repository contents. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR16-R18) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR144-R203)

**Artifact publishing improvements:**

* Updated the `publish` job to check out the correct release tag (if available) and to depend on the release outcome, ensuring that published artifacts correspond to the released code.

**Version checking improvements:**

* Updated the `check_version` job to use the correct release tag and to depend on the release outcome, ensuring version checks are performed on the released code.